### PR TITLE
feat:Customize Opportunity doctype

### DIFF
--- a/stems/custom/custom_field/opportunity.py
+++ b/stems/custom/custom_field/opportunity.py
@@ -1,0 +1,46 @@
+def get_opportunity_custom_fields():
+	'''
+	Custom fields that need to be added to the Opportunity DocType
+	'''
+	return {
+		"Opportunity": [
+			{
+				"fieldname": "site_visit_required",
+				"label": "Site Visit Required",
+				"fieldtype": "Check",
+				"insert_after": "opportunity_from",
+			},
+			{
+				"fieldname": "drawing_required",
+				"label": "Drawing Required",
+				"fieldtype": "Check",
+				"insert_after": "site_visit_required",
+			},
+			{
+				"fieldname": "site_visit_scheduled_on",
+				"label": "Site Visit Scheduled On",
+				"fieldtype": "Date",
+				"insert_after": "drawing_required",
+				"depends_on": "eval:doc.site_visit_required",
+				"mandatory_depends_on": "eval:doc.site_visit_required",
+			},
+			{
+				"fieldname": "site_engineer",
+				"label": "Site Engineer / Supervisor",
+				"fieldtype": "Link",
+				"options": "Employee",
+				"insert_after": "site_visit_scheduled_on",
+				"depends_on": "eval:doc.site_visit_required",
+				"mandatory_depends_on": "eval:doc.site_visit_required",
+				"ignore_user_permissions": 1
+			},
+						{
+				"fieldname": "lead_name",
+				"label": "Lead Name",
+				"fieldtype": "Data",
+				"insert_after": "party_name",
+				"fetch_from": "lead.lead_name",
+				"read_only": 1
+			},
+		]
+	}

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -43,7 +43,9 @@ app_license = "mit"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {
+    "Lead": "custom_scripts/lead/lead.js"
+}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -7,6 +7,8 @@ from stems.custom.custom_field.item import get_item_custom_fields
 def after_migrate():
 	# Creating STEMS specific custom fields
 	create_custom_fields(get_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_opportunity_custom_fields(), ignore_validate=True)
+	create_translations(get_custom_translations())
 
 	# Creating STEMS specific Property Setters
 	create_property_setters(get_property_setters())
@@ -53,6 +55,48 @@ def create_property_setters(property_setter_datas):
 		property_setter.flags.ignore_permissions = True
 		property_setter.insert()
 
+def create_custom_roles(roles):
+    '''
+        Method to create custom Role
+        args:
+            roles : Role List (list of string)
+        example:
+            ["Site Engineer", "Drawing User"]
+    '''
+    for role in roles:
+        if not frappe.db.exists("Role", role):
+            role_doc = frappe.get_doc({
+                "doctype": "Role",
+                "role_name": role
+            })
+            role_doc.insert(ignore_permissions=True)
+    frappe.db.commit()
+
+def create_translations(translations):
+    for translation in translations:
+        if not frappe.db.exists(translation):
+            frappe.get_doc(translation).insert(ignore_permissions=True)
+    frappe.db.commit()
+
+def get_custom_translations():
+    '''
+        Method to get Translations
+    '''
+    return [
+        {
+            'doctype': 'Translation',
+            'source_text': 'Opportunity',
+            'translated_text': 'Enquiry',
+            'language': 'en'
+        }
+    ]
+
+def get_stems_roles():
+    '''
+        Method to get Stems specific roles
+    '''
+    return ['Site Engineer','Drawing User']
+
 def get_custom_fields():
 	'''
 		Method to get custom fields to be created for STEMS
@@ -66,3 +110,50 @@ def get_property_setters():
 	'''
 	property_setters = []
 	return property_setters
+
+def get_opportunity_custom_fields():
+    '''
+    Custom fields that need to be added to the Opportunity DocType
+    '''
+    return {
+        "Opportunity": [
+            {
+                "fieldname": "site_visit_required",
+                "label": "Site Visit Required",
+                "fieldtype": "Check",
+                "insert_after": "opportunity_from",
+            },
+            {
+                "fieldname": "drawing_required",
+                "label": "Drawing Required",
+                "fieldtype": "Check",
+                "insert_after": "site_visit_required",
+            },
+            {
+                "fieldname": "site_visit_scheduled_on",
+                "label": "Site Visit Scheduled On",
+                "fieldtype": "Date",
+                "insert_after": "drawing_required",
+                "depends_on": "eval:doc.site_visit_required",
+                "mandatory_depends_on": "eval:doc.site_visit_required",
+            },
+            {
+                "fieldname": "site_engineer",
+                "label": "Site Engineer / Supervisor",
+                "fieldtype": "Link",
+                "options": "Employee",
+                "insert_after": "site_visit_scheduled_on",
+                "depends_on": "eval:doc.site_visit_required",
+                "mandatory_depends_on": "eval:doc.site_visit_required",
+                "ignore_user_permissions": 1
+            },
+                        {
+                "fieldname": "lead_name",
+                "label": "Lead Name",
+                "fieldtype": "Data",
+                "insert_after": "party_name",
+                "fetch_from": "lead.lead_name",
+                "read_only": 1
+            },
+        ]
+    }

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -3,6 +3,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 # Custom field method imports
 from stems.custom.custom_field.item import get_item_custom_fields
+from stems.custom.custom_field.opportunity import get_opportunity_custom_fields
 
 def after_migrate():
 	# Creating STEMS specific custom fields
@@ -111,49 +112,3 @@ def get_property_setters():
 	property_setters = []
 	return property_setters
 
-def get_opportunity_custom_fields():
-    '''
-    Custom fields that need to be added to the Opportunity DocType
-    '''
-    return {
-        "Opportunity": [
-            {
-                "fieldname": "site_visit_required",
-                "label": "Site Visit Required",
-                "fieldtype": "Check",
-                "insert_after": "opportunity_from",
-            },
-            {
-                "fieldname": "drawing_required",
-                "label": "Drawing Required",
-                "fieldtype": "Check",
-                "insert_after": "site_visit_required",
-            },
-            {
-                "fieldname": "site_visit_scheduled_on",
-                "label": "Site Visit Scheduled On",
-                "fieldtype": "Date",
-                "insert_after": "drawing_required",
-                "depends_on": "eval:doc.site_visit_required",
-                "mandatory_depends_on": "eval:doc.site_visit_required",
-            },
-            {
-                "fieldname": "site_engineer",
-                "label": "Site Engineer / Supervisor",
-                "fieldtype": "Link",
-                "options": "Employee",
-                "insert_after": "site_visit_scheduled_on",
-                "depends_on": "eval:doc.site_visit_required",
-                "mandatory_depends_on": "eval:doc.site_visit_required",
-                "ignore_user_permissions": 1
-            },
-                        {
-                "fieldname": "lead_name",
-                "label": "Lead Name",
-                "fieldtype": "Data",
-                "insert_after": "party_name",
-                "fetch_from": "lead.lead_name",
-                "read_only": 1
-            },
-        ]
-    }

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,20 +1,15 @@
 frappe.ui.form.on("Lead", {
-    refresh: function(frm) {
-        frm.remove_custom_button("Opportunity", "Create");
-        frm.page.remove_inner_button('Opportunity', 'Create');
+	refresh: function(frm) {
+		frm.remove_custom_button("Opportunity", "Create");
+		frm.page.remove_inner_button("Opportunity", "Create");
 
-        frm.add_custom_button(__("Enquiry"), function() {
-            frappe.call({
-                method: "stems.stems.custom_scripts.lead.lead.create_enquiry",
-                args: {
-                    lead: frm.doc.name
-                },
-                callback: function(r) {
-                    if (r.message) {
-                        frappe.set_route("Form", "Opportunity", r.message);
-                    }
-                }
-            });
-        }, __("Create"));
-    }
+		if (!frm.is_new()) {
+			frm.add_custom_button(__('Enquiry'), function() {
+				frappe.model.open_mapped_doc({
+					method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
+					source_name: frm.doc.name
+				});
+			}, __("Create"));
+		}
+	}
 });

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,0 +1,20 @@
+frappe.ui.form.on("Lead", {
+    refresh: function(frm) {
+        frm.remove_custom_button("Opportunity", "Create");
+        frm.page.remove_inner_button('Opportunity', 'Create');
+
+        frm.add_custom_button(__("Enquiry"), function() {
+            frappe.call({
+                method: "stems.stems.custom_scripts.lead.lead.create_enquiry",
+                args: {
+                    lead: frm.doc.name
+                },
+                callback: function(r) {
+                    if (r.message) {
+                        frappe.set_route("Form", "Opportunity", r.message);
+                    }
+                }
+            });
+        }, __("Create"));
+    }
+});

--- a/stems/stems/custom_scripts/lead/lead.py
+++ b/stems/stems/custom_scripts/lead/lead.py
@@ -1,0 +1,20 @@
+import frappe
+
+@frappe.whitelist()
+def create_enquiry(lead):
+    """Create a new Enquiry (Opportunity) from Lead and return Enquiry name"""
+    if not lead:
+        frappe.throw("Lead is required to create Enquiry")
+
+    lead_doc = frappe.get_doc("Lead", lead)
+
+    enquiry = frappe.new_doc("Opportunity")
+    enquiry.opportunity_from = "Lead"
+    enquiry.party_name = lead_doc.name
+    enquiry.customer_name = lead_doc.lead_name
+    enquiry.contact_email = lead_doc.email_id
+    enquiry.contact_mobile = lead_doc.phone
+
+    enquiry.insert(ignore_permissions=True)
+
+    return enquiry.name


### PR DESCRIPTION
- [x] [TASK-2025-02123]
- [x] [TASK-2025-02124]
- [x] TASK-2025-02125
- [x] TASK-2025-02126

## Feature description
Need to:
- Add translation for "Opportunity" as "Enquiry"
- Remove default "Create -> Opportunity" button from Lead
- Add custom "Create -> Enquiry" button in Lead
  - Directly creates and routes to Enquiry without Prospect dialog
  - Added backend method `make_enquiry` in lead.py
- added custom roles:
  - Site Engineer
  - Drawing User

## Solution description
- Added translation for "Opportunity" as "Enquiry"
- Removed default "Create -> Opportunity" button from Lead
- Added custom "Create -> Enquiry" button in Lead
  - Directly creates and routes to Enquiry without Prospect dialog
  - Added backend method `make_enquiry` in lead.py
- Planned/enabled custom roles:
  - Site Engineer
  - Drawing User

## Output screenshots (optional)
[Screencast from 02-09-25 03:39:49 PM IST.webm](https://github.com/user-attachments/assets/a2b3d4ff-7c2e-430c-bace-c0f22f30b0df)


## Areas affected and ensured
Opportunity doctype 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

