### PR TITLE
feat:filter Employee link field by Site Engineer role

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -44,7 +44,7 @@ app_license = "mit"
 
 # include js in doctype views
 doctype_js = {
-    "Lead": "custom_scripts/lead/lead.js",
+    "Lead": "stems/custom_scripts/lead/lead.js",
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}

--- a/stems/stems/custom_scripts/opportunity/opportunity.js
+++ b/stems/stems/custom_scripts/opportunity/opportunity.js
@@ -4,6 +4,7 @@ frappe.ui.form.on("Opportunity", {
 			add_customer_need_profile_button(frm);
 		}
 		set_item_code_query(frm);
+        set_site_engineer_query(frm);
 	}
 });
 
@@ -31,4 +32,15 @@ function set_item_code_query(frm) {
 			}
 		}
 	});
+}
+
+/*
+ * Set query for site_engineer
+ */
+function set_site_engineer_query(frm) {
+    frm.set_query("site_engineer", function() {
+        return {
+            query: "stems.stems.custom_scripts.opportunity.opportunity.get_site_engineers"
+        };
+    });
 }


### PR DESCRIPTION
## Feature description
Need to: Filter site engineer Employee link field by Site Engineer role
## Solution description

- Filtered the site engineer Employee link field by Site Engineer role
- Added corrected path for lead.js in hooks

## Output screenshots (optional)

[Screencast from 03-09-25 03:15:58 PM IST.webm](https://github.com/user-attachments/assets/6eec916f-185a-4f2a-b8b4-fba3890a4fd8)

## Areas affected and ensured
Opportunity doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
 
