### PR TITLE
feat:Map Customer Need Profile to Bill of Quantity via custom button

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
@@ -1,0 +1,85 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "BOQ-.YY.-.####",
+ "creation": "2025-09-03 11:17:13.915709",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "posting_date",
+  "lead",
+  "column_break_zf4x",
+  "customer_need_profile",
+  "customer_name",
+  "section_break_kmxa",
+  "items"
+ ],
+ "fields": [
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "customer_need_profile",
+   "fieldtype": "Link",
+   "label": "Customer Need Profile",
+   "options": "Customer Need Profile"
+  },
+  {
+   "fetch_from": "customer_need_profile.lead",
+   "fieldname": "lead",
+   "fieldtype": "Link",
+   "label": "Lead",
+   "options": "Lead"
+  },
+  {
+   "fetch_from": "lead.lead_name",
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "label": "Customer Name"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Bill of Quantity Item"
+  },
+  {
+   "fieldname": "column_break_zf4x",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_kmxa",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-09-03 15:23:18.571754",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Bill of Quantity",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/customer_need_profile/customer_need_profile.js
+++ b/stems/stems/doctype/customer_need_profile/customer_need_profile.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Customer Need Profile", {
+	refresh: function(frm) {
+		set_site_engineer_query(frm);
+		set_customer_needs_item_query(frm);
+
+		if (!frm.is_new() && frm.doc.docstatus === 1) {
+			add_bill_of_quantity_button(frm);
+		}
+	}
+});
+
+/*
+ * Set query for site_engineer_supervisor
+ */
+function set_site_engineer_query(frm) {
+	frm.set_query("site_engineer_supervisor", function() {
+		return {
+			query: "stems.stems.doctype.customer_need_profile.customer_need_profile.get_site_engineers"
+		};
+	});
+}
+
+/*
+ * Set query for item in child table customer_needs
+ */
+function set_customer_needs_item_query(frm) {
+	frm.set_query('item', 'customer_needs', () => {
+		return {
+			filters: {
+				is_cnp_item: 1,
+				is_sales_item: 1
+			}
+		}
+	});
+}
+
+/*
+ * Add button to create Bill of Quantity
+ */
+function add_bill_of_quantity_button(frm){
+	frm.add_custom_button(__('Bill of Quantity'), function() {
+		frappe.model.open_mapped_doc({
+			method: "stems.stems.doctype.customer_need_profile.customer_need_profile.make_bill_of_quantity",
+			frm: frm
+		});
+	}, __("Create"));
+}

--- a/stems/stems/doctype/customer_need_profile/customer_need_profile.json
+++ b/stems/stems/doctype/customer_need_profile/customer_need_profile.json
@@ -1,0 +1,243 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": " CNP-.YY.-.####",
+ "creation": "2025-09-02 10:14:03.127184",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "section_break_7xsu",
+  "posting_date",
+  "enquiry",
+  "customer_email",
+  "site_visit_required",
+  "site_visit_scheduled_on",
+  "site_engineer_supervisor",
+  "drawing_required",
+  "column_break_zla3",
+  "lead",
+  "customer_name",
+  "customer_phone",
+  "site_property_name",
+  "site_location",
+  "preferred_start_date",
+  "preferred_date_of_handover",
+  "section_break_lqno",
+  "billing_type",
+  "customer_provided_items",
+  "column_break_y8em",
+  "budget",
+  "section_break_ruoy",
+  "customer_remarks",
+  "customer_needs",
+  "drawing_details_section",
+  "drawn_by",
+  "drawing_attachment",
+  "column_break_d6vi",
+  "drawing_remarks",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "section_break_7xsu",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Customer Need Profile",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "fieldname": "lead",
+   "fieldtype": "Link",
+   "label": "Lead ",
+   "options": "Lead"
+  },
+  {
+   "fieldname": "enquiry",
+   "fieldtype": "Link",
+   "label": "Enquiry",
+   "options": "Opportunity"
+  },
+  {
+   "fetch_from": "enquiry.customer_name",
+   "fieldname": "customer_name",
+   "fieldtype": "Data",
+   "label": "Customer Name"
+  },
+  {
+   "fetch_from": "enquiry.contact_email",
+   "fieldname": "customer_email",
+   "fieldtype": "Data",
+   "label": "Customer Email"
+  },
+  {
+   "fetch_from": "enquiry.phone",
+   "fieldname": "customer_phone",
+   "fieldtype": "Data",
+   "label": "Customer Phone"
+  },
+  {
+   "default": "0",
+   "fetch_from": "enquiry.site_visit_required",
+   "fieldname": "site_visit_required",
+   "fieldtype": "Check",
+   "label": "Site Visit Required "
+  },
+  {
+   "default": "0",
+   "fieldname": "drawing_required",
+   "fieldtype": "Check",
+   "label": "Drawing Required"
+  },
+  {
+   "depends_on": "eval:doc.site_visit_required",
+   "fetch_from": "enquiry.site_visit_scheduled_on",
+   "fieldname": "site_visit_scheduled_on",
+   "fieldtype": "Date",
+   "label": "Site Visit Scheduled On"
+  },
+  {
+   "fieldname": "site_location",
+   "fieldtype": "Link",
+   "label": "Site Location",
+   "options": "Location"
+  },
+  {
+   "fieldname": "preferred_start_date",
+   "fieldtype": "Date",
+   "label": "Preferred Start Date"
+  },
+  {
+   "fieldname": "preferred_date_of_handover",
+   "fieldtype": "Date",
+   "label": "Preferred Date of Handover"
+  },
+  {
+   "fieldname": "customer_remarks",
+   "fieldtype": "Long Text",
+   "label": "Customer Remarks"
+  },
+  {
+   "fieldname": "customer_needs",
+   "fieldtype": "Table",
+   "label": "Customer Needs",
+   "options": "Customer Need Profile Item"
+  },
+  {
+   "depends_on": "eval:doc.drawing_required",
+   "fieldname": "drawing_details_section",
+   "fieldtype": "Section Break",
+   "label": "Drawing Details "
+  },
+  {
+   "fieldname": "drawing_attachment",
+   "fieldtype": "Attach",
+   "label": "Drawing Attachment "
+  },
+  {
+   "fieldname": "drawn_by",
+   "fieldtype": "Link",
+   "label": "Drawn By",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "drawing_remarks",
+   "fieldtype": "Small Text",
+   "label": "Drawing Remarks"
+  },
+  {
+   "fieldname": "column_break_d6vi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_zla3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_ruoy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:doc.site_visit_required",
+   "fetch_from": "enquiry.site_engineer",
+   "fieldname": "site_engineer_supervisor",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Site Engineer/Supervisor",
+   "options": "Employee"
+  },
+  {
+   "fieldname": "site_property_name",
+   "fieldtype": "Data",
+   "label": "Site/Property Name"
+  },
+  {
+   "fieldname": "section_break_lqno",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "billing_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Billing Type",
+   "options": "\nService Only\nItems\nService",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "customer_provided_items",
+   "fieldtype": "Check",
+   "label": "Customer Provided Items"
+  },
+  {
+   "fieldname": "budget",
+   "fieldtype": "Currency",
+   "label": "Budget"
+  },
+  {
+   "fieldname": "column_break_y8em",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2025-09-03 14:57:13.147979",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Customer Need Profile",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/customer_need_profile/customer_need_profile.py
+++ b/stems/stems/doctype/customer_need_profile/customer_need_profile.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
+from frappe.utils.user import get_users_with_role
+
+class CustomerNeedProfile(Document):
+	pass
+
+@frappe.whitelist()
+def make_customer_need_profile(source_name, target_doc=None):
+	"""
+		Create a Customer Need Profile from an Opportunity
+	"""
+	def set_missing_values(source, target):
+		target.posting_date = frappe.utils.nowdate()
+
+	doc = get_mapped_doc(
+		"Opportunity",
+		source_name,
+		{
+			"Opportunity": {
+				"doctype": "Customer Need Profile",
+				"field_map": {
+					"name": "enquiry",
+					"party_name": "lead",
+					"customer_name": "customer_name",
+					"contact_email": "customer_email",
+					"phone": "customer_phone",
+					"site_visit_required": "site_visit_required",
+					"drawing_required": "drawing_required",
+					"site_visit_scheduled_on": "site_visit_scheduled_on",
+					"site_engineer": "site_engineer_supervisor"
+				},
+			},
+			"Opportunity Item": {
+				"doctype": "Customer Need Profile Item",
+				"field_map": {
+					"item_code": "item",
+					"qty": "qty",
+					"uom": "uom",
+					"description": "description"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
+
+	return doc
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_site_engineers(doctype, txt, searchfield, start, page_len, filters):
+	"""
+	Fetch employees linked to users with the 'Site Engineer' role
+	for Link field searches.
+	"""
+	users = get_users_with_role("Site Engineer")
+	if not users:
+		return []
+
+	employees = frappe.get_all(
+		"Employee",
+		filters={
+			"user_id": ["in", users],
+			searchfield: ["like", f"%{txt}%"]
+		},
+		fields=["name", "employee_name"],
+		start=start,
+		page_length=page_len
+	)
+
+	return [(d.name, d.employee_name) for d in employees]
+
+@frappe.whitelist()
+def make_bill_of_quantity(source_name, target_doc=None):
+	"""
+		Create a Bill of Quantity (BOQ) document from a Customer Need Profile (CNP).
+	"""
+	def postprocess(source, target):
+		target.customer_name = source.customer_name
+
+	doc = get_mapped_doc(
+		"Customer Need Profile",
+		source_name,
+		{
+			"Customer Need Profile": {
+				"doctype": "Bill of Quantity",
+				"field_map": {
+					"name": "customer_need_profile",
+					"lead": "lead",
+					"customer_name": "customer_name"
+				}
+			},
+			"Customer Need Profile Item": {
+				"doctype": "Bill of Quantity Item",
+				"field_map": {
+					"item": "item",
+					"qty": "qty",
+					"uom": "uom"
+				},
+				"postprocess": lambda source, target, source_parent: target.update({
+					"item_name": frappe.db.get_value("Item", source.item, "item_name")
+				})
+			}
+		},
+		target_doc,
+		postprocess
+	)
+
+	return doc


### PR DESCRIPTION
## Feature description
Map Customer Need Profile to Bill of Quantity via custom button

## Solution description

- Map Customer Need Profile to Bill of Quantity via a custom button
- Added a custom button on the Customer Need Profile form to create a Bill of Quantity document.
- The button only appears after the document is submitted (docstatus = 1).
- arranged the field order in the Bill of Quantity

## Output screenshots (optional)


## Areas affected and ensured
Bill of Quantity
CNP

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
