### PR TITLE
feat:Map Customer Need Profile to Bill of Quantity via custom button

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
@@ -7,9 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "posting_date",
-  "customer_need_profile",
   "lead",
+  "column_break_zhgs",
   "customer_name",
+  "customer_need_profile",
+  "section_break_fx68",
   "items"
  ],
  "fields": [
@@ -43,12 +45,20 @@
    "fieldtype": "Table",
    "label": "Items",
    "options": "Bill of Quantity Item"
+  },
+  {
+   "fieldname": "column_break_zhgs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_fx68",
+   "fieldtype": "Section Break"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-03 12:16:24.681097",
+ "modified": "2025-09-03 16:59:02.399284",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity",

--- a/stems/stems/doctype/customer_need_profile/customer_need_profile.js
+++ b/stems/stems/doctype/customer_need_profile/customer_need_profile.js
@@ -5,6 +5,9 @@ frappe.ui.form.on("Customer Need Profile", {
 	refresh: function(frm) {
 		set_site_engineer_query(frm);
 		set_customer_needs_item_query(frm);
+		if (!frm.is_new() && frm.doc.docstatus === 1) {
+			add_bill_of_quantity_button(frm);
+		}
 	}
 });
 
@@ -31,4 +34,16 @@ function set_customer_needs_item_query(frm) {
 			}
 		}
 	});
+}
+
+/*
+ * Add button to create Bill of Quantity
+ */
+function add_bill_of_quantity_button(frm){
+	frm.add_custom_button(__('Bill of Quantity'), function() {
+		frappe.model.open_mapped_doc({
+			method: "stems.stems.doctype.customer_need_profile.customer_need_profile.make_bill_of_quantity",
+			frm: frm
+		});
+	}, __("Create"));
 }


### PR DESCRIPTION
## Feature description

- Map Customer Need Profile to Bill of Quantity via custom button

## Solution description

- [x] TASK-2025-02146

- Map Customer Need Profile to Bill of Quantity via a custom button
- Added a custom button on the Customer Need Profile form to create a Bill of Quantity document.
- The button only appears after the document is submitted (docstatus = 1).
- arranged the field order in the Bill of Quantity

## Output screenshots (optional)

[Screencast from 03-09-25 04:49:04 PM IST.webm](https://github.com/user-attachments/assets/12925186-9dc5-4e83-b9c9-b923f343f998)

## Areas affected and ensured

- Bill of Quantity
- CNP

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
