### PR TITLE
TASK-2025-02119,TASK-2025-02120:Assign Lead to sales person on creating a Lead document

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -47,9 +47,9 @@ doctype_js = {
     "Lead": "stems/custom_scripts/lead/lead.js",
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js"
 }
-# doctype_list_js = {
-#     "Lead" : "stems/custom_scripts/lead/lead_list.js"
-#     }
+doctype_list_js = {
+    "Lead" : "stems/custom_scripts/lead/lead_list.js"
+    }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -153,7 +153,7 @@ doc_events = {
         "on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update"
     },
     "Lead": {
-        "validate": "stems.stems.custom_scripts.lead.lead.auto_assign_lead"
+        "on_update": "stems.stems.custom_scripts.lead.lead.auto_assign_lead"
     }
 }
 

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -142,7 +142,7 @@ before_uninstall = "stems.install.before_uninstall"
 
 # override_doctype_class = {
 # 	"ToDo": "custom_app.overrides.CustomToDo"
-# }=
+# }
 
 # Document Events
 # ---------------

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -47,7 +47,9 @@ doctype_js = {
     "Lead": "stems/custom_scripts/lead/lead.js",
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js"
 }
-# doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
+# doctype_list_js = {
+#     "Lead" : "stems/custom_scripts/lead/lead_list.js"
+#     }
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
@@ -140,7 +142,7 @@ before_uninstall = "stems.install.before_uninstall"
 
 # override_doctype_class = {
 # 	"ToDo": "custom_app.overrides.CustomToDo"
-# }
+# }=
 
 # Document Events
 # ---------------
@@ -149,6 +151,9 @@ before_uninstall = "stems.install.before_uninstall"
 doc_events = {
     "Opportunity": {
         "on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update"
+    },
+    "Lead": {
+        "validate": "stems.stems.custom_scripts.lead.lead.auto_assign_lead"
     }
 }
 

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -10,6 +10,8 @@ from stems.custom.custom_field.quotation import get_quotation_custom_fields
 def after_migrate():
 	# Creating STEMS specific custom fields
 	create_custom_fields(get_custom_fields(), ignore_validate=True)
+	create_custom_fields(get_lead_custom_fields(), ignore_validate=True)
+
 
 	# Creating STEMS specific custom roles
 	create_custom_roles(get_stems_roles())
@@ -34,6 +36,7 @@ def delete_custom_fields_for_stems():
 	delete_custom_fields(get_item_custom_fields())
 	delete_custom_fields(get_opportunity_custom_fields())
 	delete_custom_fields(get_quotation_custom_fields())
+	delete_custom_fields(get_lead_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
 	'''
@@ -123,3 +126,19 @@ def get_property_setters():
 	property_setters = []
 	return property_setters
 
+
+def get_lead_custom_fields():
+	'''
+	Custom fields that need to be added to the Lead doctype
+	'''
+	return {
+		"Lead": [
+			{
+				"fieldname": "sales_person",
+				"fieldtype": "Link",
+				"label": "Sales Person",
+				"options": "Employee",
+				"insert_after": "source"
+			}
+		]
+	}

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -17,6 +17,9 @@ frappe.ui.form.on("Lead", {
     }
 });
 
+/*
+ * Set query for Sales User
+ */
 function set_sales_person_query(frm) {
     frm.set_query("sales_person", function() {
         return {

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -11,5 +11,16 @@ frappe.ui.form.on("Lead", {
 				});
 			}, __("Create"));
 		}
-	}
+	},
+	setup: function(frm) {
+		set_sales_person_query(frm);
+    }
 });
+
+function set_sales_person_query(frm) {
+    frm.set_query("sales_person", function() {
+        return {
+            query: "stems.stems.custom_scripts.lead.lead.get_sales_user_employees"
+        };
+    });
+}

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,29 +1,7 @@
 frappe.ui.form.on("Lead", {
     refresh: function(frm) {
         setTimeout(() => {
-            // Remove Create buttons
-            frm.remove_custom_button("Opportunity", "Create");
-            frm.remove_custom_button("Prospect", "Create");
-            if (frm.page && frm.page.remove_inner_button) {
-                frm.page.remove_inner_button("Opportunity", "Create");
-                frm.page.remove_inner_button("Prospect", "Create");
-            }
-
-            // Remove Action button
-            frm.remove_custom_button("Add to Prospect", "Action");
-            if (frm.page && frm.page.remove_inner_button) {
-                frm.page.remove_inner_button("Add to Prospect", "Action");
-            }
-
-            // Add Enquiry button under Create group
-            if (!frm.is_new()) {
-                frm.add_custom_button(__('Enquiry'), function() {
-                    frappe.model.open_mapped_doc({
-                        method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
-                        source_name: frm.doc.name
-                    });
-                }, __("Create"));
-            }
+            customize_lead_buttons(frm);
         }, 100);
     },
     setup: function(frm) {
@@ -41,3 +19,32 @@ function set_sales_person_query(frm) {
         };
     });
 }
+
+/*
+ * Function to Add and remove custom buttons on Lead form
+ */
+function customize_lead_buttons(frm) {
+    frm.remove_custom_button("Opportunity", "Create");
+    frm.remove_custom_button("Prospect", "Create");
+    if (frm.page && frm.page.remove_inner_button) {
+        frm.page.remove_inner_button("Opportunity", "Create");
+        frm.page.remove_inner_button("Prospect", "Create");
+    }
+
+    // Remove Action buttons
+    frm.remove_custom_button("Add to Prospect", "Action");
+    if (frm.page && frm.page.remove_inner_button) {
+        frm.page.remove_inner_button("Add to Prospect", "Action");
+    }
+
+    // Add Enquiry button under Create group
+    if (!frm.is_new()) {
+        frm.add_custom_button(__('Enquiry'), function() {
+            frappe.model.open_mapped_doc({
+                method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
+                source_name: frm.doc.name
+            });
+        }, __("Create"));
+    }
+}
+

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,7 +1,12 @@
 frappe.ui.form.on("Lead", {
 	refresh: function(frm) {
-		frm.remove_custom_button("Opportunity", "Create");
-		frm.page.remove_inner_button("Opportunity", "Create");
+		setTimeout(() => {
+			frm.remove_custom_button("Opportunity", "Create");
+			frm.remove_custom_button("Prospect", "Create");
+
+			if (frm.page && frm.page.remove_inner_button) {
+				frm.page.remove_inner_button("Opportunity", "Create");
+			}
 
 		if (!frm.is_new()) {
 			frm.add_custom_button(__('Enquiry'), function() {
@@ -11,6 +16,7 @@ frappe.ui.form.on("Lead", {
 				});
 			}, __("Create"));
 		}
+		}, 10); 
 	},
 	setup: function(frm) {
 		set_sales_person_query(frm);

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,25 +1,33 @@
 frappe.ui.form.on("Lead", {
-	refresh: function(frm) {
-		setTimeout(() => {
-			frm.remove_custom_button("Opportunity", "Create");
-			frm.remove_custom_button("Prospect", "Create");
+    refresh: function(frm) {
+        setTimeout(() => {
+            // Remove Create buttons
+            frm.remove_custom_button("Opportunity", "Create");
+            frm.remove_custom_button("Prospect", "Create");
+            if (frm.page && frm.page.remove_inner_button) {
+                frm.page.remove_inner_button("Opportunity", "Create");
+                frm.page.remove_inner_button("Prospect", "Create");
+            }
 
-			if (frm.page && frm.page.remove_inner_button) {
-				frm.page.remove_inner_button("Opportunity", "Create");
-			}
+            // Remove Action button
+            frm.remove_custom_button("Add to Prospect", "Action");
+            if (frm.page && frm.page.remove_inner_button) {
+                frm.page.remove_inner_button("Add to Prospect", "Action");
+            }
 
-		if (!frm.is_new()) {
-			frm.add_custom_button(__('Enquiry'), function() {
-				frappe.model.open_mapped_doc({
-					method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
-					source_name: frm.doc.name
-				});
-			}, __("Create"));
-		}
-		}, 10); 
-	},
-	setup: function(frm) {
-		set_sales_person_query(frm);
+            // Add Enquiry button under Create group
+            if (!frm.is_new()) {
+                frm.add_custom_button(__('Enquiry'), function() {
+                    frappe.model.open_mapped_doc({
+                        method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
+                        source_name: frm.doc.name
+                    });
+                }, __("Create"));
+            }
+        }, 100);
+    },
+    setup: function(frm) {
+        set_sales_person_query(frm);
     }
 });
 

--- a/stems/stems/custom_scripts/lead/lead.py
+++ b/stems/stems/custom_scripts/lead/lead.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
-
+from frappe.utils.user import get_users_with_role
+from frappe.desk.form.assign_to import add as add_assignment, clear as clear_assignment
 @frappe.whitelist()
 def make_enquiry(source_name, target_doc=None):
     """Create a new Enquiry (Opportunity) from Lead and return Enquiry name"""
@@ -33,3 +34,61 @@ def make_enquiry(source_name, target_doc=None):
         set_missing_values
     )
     return doc
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_sales_user_employees(doctype, txt, searchfield, start, page_len, filters):
+    """
+    Fetch employees linked to users with the 'Sales User' role
+    for filtering the Sales Person field in Lead.
+    """
+    users = get_users_with_role("Sales User")
+    if not users:
+        return []
+
+    employees = frappe.get_all(
+        "Employee",
+        filters={
+            "user_id": ["in", users],
+            searchfield: ["like", f"%{txt}%"]
+        },
+        fields=["name", "employee_name"],
+        start=start,
+        page_length=page_len
+    )
+
+    return [(d.name, d.employee_name) for d in employees]
+
+def auto_assign_lead(doc, method=None):
+    """
+    Assign Lead to the User linked to the Employee selected in Sales Person field.
+    Runs on validate (before save). Uses an exist check to ensure assignment only after the Lead exists.
+    """
+
+    # Only assign if Sales Person is selected
+    if not doc.sales_person:
+        return
+
+    # Check if the Lead exists in DB (not a new doc)
+    if not frappe.db.exists("Lead", doc.name):
+        return
+
+    employee = doc.sales_person
+    user_id = frappe.db.get_value("Employee", employee, "user_id")
+
+    if not user_id:
+        return
+
+    # Clear old assignments to avoid duplicates
+    clear_assignment("Lead", doc.name)
+
+    # Create new assignment
+    add_assignment({
+        "assign_to": [user_id],
+        "doctype": "Lead",
+        "name": doc.name,
+        "description": f"Auto-assigned Lead {doc.name} to {user_id}",
+        "assigned_by": frappe.session.user
+    })
+
+

--- a/stems/stems/custom_scripts/lead/lead_list.js
+++ b/stems/stems/custom_scripts/lead/lead_list.js
@@ -1,0 +1,79 @@
+// // File: stems/custom_scripts/lead/lead.js
+
+// frappe.listview_settings['Lead'] = {
+//     onload(listview) {
+//         listview.page.add_inner_button(__('Assign Salespersons'), function() {
+//             // Prompt user to select Employee to assign
+//             frappe.prompt({
+//                 fieldname: 'sales_person',
+//                 fieldtype: 'Link',
+//                 label: 'Sales Person',
+//                 options: 'Employee',
+//                 reqd: 1
+//             }, async function(values) {
+//                 const emp = values.sales_person;
+
+//                 // Get linked user for Employee
+//                 let emp_user = await frappe.db.get_value('Employee', emp, 'user_id');
+//                 if (!emp_user || !emp_user.message.user_id) {
+//                     frappe.msgprint(__('Selected Employee has no linked User'));
+//                     return;
+//                 }
+
+//                 const user_id = emp_user.message.user_id;
+
+//                 // Check if linked user has Sales User role
+//                 const role_check = await frappe.call({
+//                     method: "frappe.client.get_list",
+//                     args: {
+//                         doctype: "Has Role",
+//                         filters: { parent: user_id, role: "Sales User" },
+//                         fields: ["role"]
+//                     }
+//                 });
+
+//                 if (!role_check.message.length) {
+//                     frappe.msgprint(__('Selected Employee is not a Sales User'));
+//                     return;
+//                 }
+
+//                 // Get selected Leads in ListView
+//                 const selected_leads = listview.get_checked_items();
+//                 if (!selected_leads.length) {
+//                     frappe.msgprint(__('Please select at least one Lead'));
+//                     return;
+//                 }
+
+//                 // Assign the selected Employee to each Lead
+//                 for (let lead of selected_leads) {
+//                     await frappe.db.set_value('Lead', lead.name, 'sales_person', emp);
+//                 }
+
+//                 frappe.msgprint(__('Assigned {0} to {1} Leads', [emp, selected_leads.length]));
+//                 listview.refresh();
+//             }, __('Assign Sales Person'), __('Assign'));
+//         });
+//     }
+// };
+
+
+frappe.listview_settings['Lead'] = {
+    onload: function(listview) {
+        listview.page.add_inner_button(__('Assign to Sales Users'), async function() {
+            let selected = listview.get_checked_items();
+            if (!selected.length) {
+                frappe.msgprint(__('Please select at least one record'));
+                return;
+            }
+
+            for (let doc of selected) {
+                let result = await frappe.call({
+                    method: "stems.stems.custom_scripts.lead.lead.assign_to_sales_users",
+                    args: { docname: doc.name }
+                });
+                frappe.msgprint(__('Assigned to: ') + result.message.join(", "));
+            }
+            listview.refresh();
+        });
+    }
+};

--- a/stems/stems/custom_scripts/lead/lead_list.js
+++ b/stems/stems/custom_scripts/lead/lead_list.js
@@ -1,79 +1,63 @@
-// // File: stems/custom_scripts/lead/lead.js
-
-// frappe.listview_settings['Lead'] = {
-//     onload(listview) {
-//         listview.page.add_inner_button(__('Assign Salespersons'), function() {
-//             // Prompt user to select Employee to assign
-//             frappe.prompt({
-//                 fieldname: 'sales_person',
-//                 fieldtype: 'Link',
-//                 label: 'Sales Person',
-//                 options: 'Employee',
-//                 reqd: 1
-//             }, async function(values) {
-//                 const emp = values.sales_person;
-
-//                 // Get linked user for Employee
-//                 let emp_user = await frappe.db.get_value('Employee', emp, 'user_id');
-//                 if (!emp_user || !emp_user.message.user_id) {
-//                     frappe.msgprint(__('Selected Employee has no linked User'));
-//                     return;
-//                 }
-
-//                 const user_id = emp_user.message.user_id;
-
-//                 // Check if linked user has Sales User role
-//                 const role_check = await frappe.call({
-//                     method: "frappe.client.get_list",
-//                     args: {
-//                         doctype: "Has Role",
-//                         filters: { parent: user_id, role: "Sales User" },
-//                         fields: ["role"]
-//                     }
-//                 });
-
-//                 if (!role_check.message.length) {
-//                     frappe.msgprint(__('Selected Employee is not a Sales User'));
-//                     return;
-//                 }
-
-//                 // Get selected Leads in ListView
-//                 const selected_leads = listview.get_checked_items();
-//                 if (!selected_leads.length) {
-//                     frappe.msgprint(__('Please select at least one Lead'));
-//                     return;
-//                 }
-
-//                 // Assign the selected Employee to each Lead
-//                 for (let lead of selected_leads) {
-//                     await frappe.db.set_value('Lead', lead.name, 'sales_person', emp);
-//                 }
-
-//                 frappe.msgprint(__('Assigned {0} to {1} Leads', [emp, selected_leads.length]));
-//                 listview.refresh();
-//             }, __('Assign Sales Person'), __('Assign'));
-//         });
-//     }
-// };
-
-
 frappe.listview_settings['Lead'] = {
     onload: function(listview) {
-        listview.page.add_inner_button(__('Assign to Sales Users'), async function() {
-            let selected = listview.get_checked_items();
-            if (!selected.length) {
-                frappe.msgprint(__('Please select at least one record'));
+        listview.page.add_inner_button(__('Assign Sales Person'), function() {
+
+            // Get selected leads from the list view
+            const selected_leads = listview.get_checked_items();
+
+            if (!selected_leads.length) {
+                frappe.msgprint(__('Please select at least one Lead'));
                 return;
             }
 
-            for (let doc of selected) {
-                let result = await frappe.call({
-                    method: "stems.stems.custom_scripts.lead.lead.assign_to_sales_users",
-                    args: { docname: doc.name }
-                });
-                frappe.msgprint(__('Assigned to: ') + result.message.join(", "));
-            }
-            listview.refresh();
+            const d = new frappe.ui.Dialog({
+                title: __('Assign Sales Person'),
+                fields: [
+                    {
+                        label: 'Sales Person',
+                        fieldname: 'sales_user',
+                        fieldtype: 'Link',
+                        options: 'Employee',
+                        get_query: function() {
+                            return {
+                                query: 'stems.stems.custom_scripts.lead.lead.get_sales_user_employees'
+                            };
+                        },
+                        reqd: 1
+                    }
+                ],
+                primary_action_label: 'Assign',
+                primary_action: function(values) {
+                    const sales_user = values.sales_user;
+
+                    if (!sales_user) {
+                        frappe.msgprint(__('Please select a Sales Person'));
+                        return;
+                    }
+
+                    // Call backend method to assign each lead to selected sales person
+                    frappe.call({
+                        method: "stems.stems.custom_scripts.lead.lead.bulk_assign_lead",
+                        args: {
+                            docnames: selected_leads.map(l => l.name),
+                            sales_user: sales_user
+                        },
+                        callback: function(r) {
+                            if (!r.exc) {
+                                frappe.show_alert({
+                                    message: __('Assigned {0} lead(s) to {1}', [selected_leads.length, sales_user]),
+                                    indicator: 'green'
+                                });
+                                listview.refresh();
+                            }
+                        }
+                    });
+
+                    d.hide();
+                }
+            });
+
+            d.show();
         });
     }
 };


### PR DESCRIPTION
## Feature description
On creating a lead document assign to Sales user.

## Analysis and design (optional)
- Add Custom field Sales Person in Lead doctype (Link to Employee doctype, Ignore User Permission) 
- Apply filter with Employee users having Sales User role

## Output screenshots (optional)
[Screencast from 04-09-25 09:51:37 AM IST.webm](https://github.com/user-attachments/assets/fe39c91a-1e82-4be9-b19d-c513c6c7f9c7)

## Areas affected and ensured
Lead doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
