### PR TITLE
feat:doctype for stems settings

### DIFF
--- a/stems/stems/doctype/stems_settings/stems_settings.js
+++ b/stems/stems/doctype/stems_settings/stems_settings.js
@@ -1,0 +1,21 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('STEMS Settings', {
+	refresh: function(frm) {
+		set_quotation_print_format(frm);
+	}
+});
+
+/*
+ * filter Quotation Print Format to show only those with doc_type as Quotation
+ */
+function set_quotation_print_format(frm) {
+	frm.set_query('quotation_print_format', () => {	
+		return {
+			filters: {
+				doc_type: 'Quotation'
+			}
+		}
+	});	
+}

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -1,0 +1,74 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-09-04 09:50:56.489295",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "notification_settings_section",
+  "enable_quotation_approval_notifcation",
+  "quotation_approval_notifcation_template",
+  "column_break_zbaj",
+  "quotation_print_format"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "description": "Enabling this will send Quotation to Customer for thier approval",
+   "fieldname": "enable_quotation_approval_notifcation",
+   "fieldtype": "Check",
+   "label": "Enable Quotation Approval Notifcation"
+  },
+  {
+   "depends_on": "eval:doc.enable_quotation_approval_notifcation",
+   "fieldname": "quotation_approval_notifcation_template",
+   "fieldtype": "Link",
+   "label": "Quotation Approval Notifcation Template",
+   "mandatory_depends_on": "eval:doc.enable_quotation_approval_notifcation",
+   "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.enable_quotation_approval_notifcation",
+   "description": "System will use standard print format if it's not set",
+   "fieldname": "quotation_print_format",
+   "fieldtype": "Link",
+   "label": "Quotation Print Format",
+   "options": "Print Format"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "notification_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Notification Settings"
+  },
+  {
+   "fieldname": "column_break_zbaj",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-09-04 10:08:52.939497",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "STEMS Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/stems_settings/stems_settings.py
+++ b/stems/stems/doctype/stems_settings/stems_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class STEMSSettings(Document):
+	pass

--- a/stems/stems/doctype/stems_settings/test_stems_settings.py
+++ b/stems/stems/doctype/stems_settings/test_stems_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSTEMSSettings(FrappeTestCase):
+	pass


### PR DESCRIPTION
## Feature description
doctype for stems settings

## Solution description

- [x] TASK-2025-02151

- Created doctype for stems settings
- Added a client-side query function in STEMS Settings to restrict the Quotation Print Format field.
- Now the Link field will only show Print Formats where doc_type = "Quotation".

## Output screenshots (optional)
<img width="1418" height="684" alt="image" src="https://github.com/user-attachments/assets/b7f140c0-9fd1-49f5-84f7-4026763dfb9f" />


## Areas affected and ensured
STEMS Settings

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
