### PR TITLE
TASK-2025-02148:Map Bill of Quantity to Quotation via custom button

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -1,8 +1,22 @@
 // Copyright (c) 2025, efeone and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Bill of Quantity", {
-// 	refresh(frm) {
+frappe.ui.form.on('Bill of Quantity', {
+    refresh: function(frm) {
+        if (!frm.is_new()) {
+            add_make_quotation_button(frm);
+        }
+    }
+});
 
-// 	},
-// });
+/*
+ * Add button to create Quotation from Bill of Quantity
+ */
+function add_make_quotation_button(frm) {
+    frm.add_custom_button(__('Quotation'), function() {
+        frappe.model.open_mapped_doc({
+            method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.make_quotation",
+            frm: frm
+        });
+    }, __("Create"));
+}

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -1,9 +1,60 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.model.mapper import get_mapped_doc
 
 
 class BillofQuantity(Document):
 	pass
+
+
+@frappe.whitelist()
+def make_quotation(source_name, target_doc=None):
+	"""Map BOQ to Quotation with custom item rules"""
+
+	def set_missing_values(source, target):
+
+		target.quotation_to = "Lead"
+		target.party_name = source.lead
+		target.customer_name = frappe.db.get_value("Lead", source.lead, "lead_name")
+
+		if source.customer_need_profile:
+			cnp = frappe.get_doc("Customer Need Profile", source.customer_need_profile)
+
+			if cnp.billing_type == "Items and Service" and cnp.customer_provided_items:
+				for item in source.items:
+					target.append("items", {
+						"item_code": item.item,
+						"item_name": item.item_name,
+						"qty": item.qty,
+						"uom": item.uom
+					})
+
+		for item in source.items:
+			target.append("required_items", {
+				"item_code": item.item,
+				"item_name": item.item_name,
+				"qty": item.qty,
+				"uom": item.uom
+			})
+
+	doc = get_mapped_doc(
+		"Bill of Quantity",
+		source_name,
+		{
+			"Bill of Quantity": {
+				"doctype": "Quotation",
+				"field_map": {
+					"lead": "party",
+					"customer_name": "customer_name",
+					"customer_need_profile": "customer_need_profile"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
+
+	return doc

--- a/stems/stems/doctype/customer_need_profile/customer_need_profile.json
+++ b/stems/stems/doctype/customer_need_profile/customer_need_profile.json
@@ -192,7 +192,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Billing Type",
-   "options": "\nService Only\nItems\nService",
+   "options": "\nService Only\nItems and Service",
    "reqd": 1
   },
   {
@@ -215,7 +215,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-03 12:24:02.236629",
+ "modified": "2025-09-04 10:12:27.519845",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Customer Need Profile",


### PR DESCRIPTION
## Feature description
Need to: Map Bill of Quantity to Quotation via custom button
               Map Items to Required Items   If Billing Type == 'Items and Service' and Customer Provided Items == 1, then Map Items to Items as well. Else Keep Items blank while Map Doc


## Solution description

- Mapped Customer Need Profile to Bill of Quantity via a custom button
- Mapped Items to Required Items   If Billing Type == 'Items and Service' and Customer Provided Items == 1, then Map Items to Items as well. Else Keep Items blank while Map Doc

- Updated Billing Type options into
  * Service Only
  * Items and Service

## Output screenshots (optional)
[Screencast from 04-09-25 11:36:57 AM IST.webm](https://github.com/user-attachments/assets/c15dbf9b-adf4-4cab-b4e7-13952d7f6b77)

[Screencast from 04-09-25 11:37:40 AM IST.webm](https://github.com/user-attachments/assets/a0969ce5-8308-47b9-96dc-d8507ca89c09)


## Areas affected and ensured
Quotation doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

