### PR TITLE
feat: Sales Order from Quotation

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -45,7 +45,8 @@ app_license = "mit"
 # include js in doctype views
 doctype_js = {
     "Lead": "stems/custom_scripts/lead/lead.js",
-	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js"
+	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js",
+	"Quotation":"stems/custom_scripts/quotation/quotation.js"
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/stems/stems/custom_scripts/quotation/quotation.js
+++ b/stems/stems/custom_scripts/quotation/quotation.js
@@ -1,0 +1,30 @@
+frappe.ui.form.on('Quotation', {
+	refresh: function(frm) {
+		setTimeout(() => {
+			remove_default_sales_order_button(frm);
+			add_custom_sales_order_button(frm);
+		}, 5);
+	}
+});
+
+/**
+ * Remove the default Sales Order button under "Create"
+ */
+function remove_default_sales_order_button(frm) {
+	frm.remove_custom_button('Sales Order', 'Create');
+}
+
+/**
+ * Add a custom Sales Order button under "Create"
+ * Only visible if Quotation is Customer Approved
+ */
+function add_custom_sales_order_button(frm) {
+	if (frm.doc.docstatus === 1 && frm.doc.workflow_state === "Customer Approved") {
+		frm.add_custom_button(__('Sales Order'), () => {
+			frappe.model.open_mapped_doc({
+				method: 'stems.stems.custom_scripts.quotation.quotation.make_sales_order_from_quotation',
+				frm: frm
+			});
+		}, __('Create'));
+	}
+}

--- a/stems/stems/custom_scripts/quotation/quotation.py
+++ b/stems/stems/custom_scripts/quotation/quotation.py
@@ -1,0 +1,39 @@
+import frappe
+from frappe.model.mapper import get_mapped_doc
+
+@frappe.whitelist()
+def make_sales_order_from_quotation(source_name, target_doc=None):
+	"""
+		Create a Sales Order from a Quotation.
+	"""
+	def set_missing_values(source, target):
+		target.customer = source.party_name
+		target.delivery_date = frappe.utils.nowdate()
+
+	doclist = get_mapped_doc(
+		"Quotation",
+		source_name,
+		{
+			"Quotation": {
+				"doctype": "Sales Order",
+				"field_map": {
+					"name": "quotation"        
+				}
+			},
+			"Quotation Item": {
+				"doctype": "Sales Order Item",
+				"field_map": {
+					"parent": "parent"
+				}
+			},
+			"Required Items": {
+				"doctype": "Sales Order Item",
+				"field_map": {
+					"parent": "parent"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
+	return doclist


### PR DESCRIPTION
## Feature description

enable Sales Order creation from approved Quotation with item mappings

## Solution description

- [ ] TASK-2025-02154

- Removed Create -> Sales Order button in Quotation 
- Bring custom Create -> Sales Order button in Quotation 
- Create -> Sales Order button should be only for Customer Approved
-  Quotation Map Items with Items , Map Required Items to  Items

## Output screenshots (optional)

[Screencast from 04-09-25 02:00:12 PM IST.webm](https://github.com/user-attachments/assets/578f1906-5b85-4476-b133-a75c4a16a2e6)


## Areas affected and ensured
- Sales Order

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
