### PR TITLE
fix:apply item code filter when Opportunity is created from Lead

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.js
+++ b/stems/stems/custom_scripts/opportunity/opportunity.js
@@ -1,10 +1,12 @@
 frappe.ui.form.on("Opportunity", {
+	onload_post_render: function(frm) {
+		set_item_code_query(frm);
+	},
 	refresh: function(frm) {
 		if (!frm.is_new()) {
 			add_customer_need_profile_button(frm);
 		}
-		set_item_code_query(frm);
-        set_site_engineer_query(frm);
+		set_site_engineer_query(frm);
 	}
 });
 
@@ -38,9 +40,9 @@ function set_item_code_query(frm) {
  * Set query for site_engineer
  */
 function set_site_engineer_query(frm) {
-    frm.set_query("site_engineer", function() {
-        return {
-            query: "stems.stems.custom_scripts.opportunity.opportunity.get_site_engineers"
-        };
-    });
+	frm.set_query("site_engineer", function() {
+		return {
+			query: "stems.stems.custom_scripts.opportunity.opportunity.get_site_engineers"
+		};
+	});
 }


### PR DESCRIPTION
## Feature description
apply item_code filter when creating Opportunity from Lead

## Solution description

- [ ] TASK-2025-02175

issue fixed:

- Item code filter was not working when creating an Opportunity from a Lead,  it only worked when creating a new Opportunity directly.
- Moved item_code query setup outside is_new() check
- Ensures filters (is_cnp_item=1, is_sales_item=1) work for both direct creation
  and when Opportunity is mapped from a Lead

## Output screenshots (optional)


[Screencast from 08-09-25 11:06:53 AM IST.webm](https://github.com/user-attachments/assets/98aad685-b877-4fab-a2a5-c37626d7110a)

## Areas affected and ensured

- Opportunity

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
