### PR TITLE
fix:Create a Sales Order from a Quotation

### DIFF
--- a/stems/stems/custom_scripts/quotation/quotation.py
+++ b/stems/stems/custom_scripts/quotation/quotation.py
@@ -1,41 +1,80 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
 from frappe.email.doctype.email_template.email_template import get_email_template
+from frappe.utils import getdate, nowdate
+from frappe import _
+from erpnext.selling.doctype.quotation.quotation import _make_customer, get_ordered_items
 
 @frappe.whitelist()
-def make_sales_order_from_quotation(source_name, target_doc=None):
+def make_sales_order_from_quotation(source_name: str, target_doc=None):
 	"""
 		Create a Sales Order from a Quotation.
+		Delegate to `_make_sales_order_from_quotation` to perform actual mapping.
 	"""
-	def set_missing_values(source, target):
-		target.customer = source.party_name
-		target.delivery_date = frappe.utils.nowdate()
+	if not frappe.db.get_singles_value(
+		"Selling Settings", "allow_sales_order_creation_for_expired_quotation"
+	):
+		quotation = frappe.db.get_value(
+			"Quotation", source_name, ["transaction_date", "valid_till"], as_dict=1
+		)
+		if quotation.valid_till and (
+			quotation.valid_till < quotation.transaction_date or quotation.valid_till < getdate(nowdate())
+		):
+			frappe.throw(_("Validity period of this quotation has ended."))
 
-	doclist = get_mapped_doc(
+	return _make_sales_order_from_quotation(source_name, target_doc)
+
+def _make_sales_order_from_quotation(source_name, target_doc=None, ignore_permissions=False):
+	"""
+		- Map only the standard `items` child table, ignoring `required_items`
+		- Only map items with qty > 0.
+		- Set customer details from Quotation.
+		- If referral sales partner exists, map commission details.
+		- Run standard ERPNext hooks: `set_missing_values` and `calculate_taxes_and_totals`.
+	"""
+	customer = _make_customer(source_name, ignore_permissions)
+	ordered_items = get_ordered_items(source_name)
+
+	selected_rows = [x.get("name") for x in frappe.flags.get("args", {}).get("selected_items", [])]
+	has_unit_price_items = frappe.db.get_value("Quotation", source_name, "has_unit_price_items")
+
+	def is_unit_price_row(source) -> bool:
+		return has_unit_price_items and source.qty == 0
+
+	def set_missing_values(source, target):
+		if customer:
+			target.customer = customer.name
+			target.customer_name = customer.customer_name
+
+		if source.referral_sales_partner:
+			target.sales_partner = source.referral_sales_partner
+			target.commission_rate = frappe.get_value(
+				"Sales Partner", source.referral_sales_partner, "commission_rate"
+			)
+
+		target.flags.ignore_permissions = ignore_permissions
+		target.run_method("set_missing_values")
+		target.run_method("calculate_taxes_and_totals")
+
+	return get_mapped_doc(
 		"Quotation",
 		source_name,
 		{
 			"Quotation": {
 				"doctype": "Sales Order",
-				"field_map": {
-					"name": "quotation"        
-				}
+				"validation": {"docstatus": ["=", 1]},
 			},
 			"Quotation Item": {
 				"doctype": "Sales Order Item",
 				"field_map": {
-					"parent": "parent"
-				}
+					"parent": "prevdoc_docname",
+					"name": "quotation_item"
+				},
+				"condition": lambda d: d.parentfield == "items" and d.qty > 0
 			},
-			"Required Items": {
-				"doctype": "Sales Order Item",
-				"field_map": {
-					"parent": "parent"
-				}
-			}
 		},
 		target_doc,
-		set_missing_values
+		set_missing_values,
 	)
 	return doclist
 


### PR DESCRIPTION
## Feature description

Create a Sales Order from a Quotation

## Solution description
Create a Sales Order from a Quotation
- Added validation for expired quotations (respecting Selling Settings)
- Introduced `_make_sales_order_from_quotation` for cleaner mapping logic
- Map only `items` child table (ignore `required_items`)
- Ensure only items with qty > 0 are mapped
- Added support for referral sales partner commission mapping
- Set customer details via `_make_customer`
- Run standard ERPNext methods: set_missing_values & calculate_taxes_and_totals

## Output screenshots (optional)

[Screencast from 09-09-25 09:47:18 AM IST.webm](https://github.com/user-attachments/assets/643f8275-a25c-4112-be9d-a52984cb2a31)

<img width="1554" height="974" alt="image" src="https://github.com/user-attachments/assets/69615c23-bbe5-45ba-a6bd-7c82a1ddb15c" />


## Areas affected and ensured
sales order
customer

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
