### PR TITLE
TASK-2026-00017 'BOQ' button to generate BOQs from Enquiries

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.js
+++ b/stems/stems/custom_scripts/opportunity/opportunity.js
@@ -1,38 +1,59 @@
 frappe.ui.form.on("Opportunity", {
-	onload_post_render: function(frm) {
+	onload_post_render: function (frm) {
 		set_item_code_query(frm);
 	},
-	refresh: function(frm) {
+	refresh: function (frm) {
 		if (!frm.is_new()) {
 			add_customer_need_profile_button(frm);
+			add_boq_button(frm);
 		}
 		set_site_engineer_query(frm);
-	}
+	},
 });
 
 /*
  * Add custom button for creating Customer Need Profile
  */
 function add_customer_need_profile_button(frm) {
-	frm.add_custom_button(__('Customer Need Profile'), function() {
-		frappe.model.open_mapped_doc({
-			method: "stems.stems.doctype.customer_need_profile.customer_need_profile.make_customer_need_profile",
-			frm: frm
-		});
-	}, __("Create"));
+	frm.add_custom_button(
+		__("Customer Need Profile"),
+		function () {
+			frappe.model.open_mapped_doc({
+				method: "stems.stems.doctype.customer_need_profile.customer_need_profile.make_customer_need_profile",
+				frm: frm,
+			});
+		},
+		__("Create")
+	);
+}
+
+/*
+ * Add custom button for creating BOQ
+ */
+function add_boq_button(frm) {
+	frm.add_custom_button(
+		__("BOQ"),
+		function () {
+			frappe.model.open_mapped_doc({
+				method: "stems.stems.custom_scripts.opportunity.opportunity.make_boq",
+				frm: frm,
+			});
+		},
+		__("Create")
+	);
 }
 
 /*
  * Set query for item_code in child table
  */
 function set_item_code_query(frm) {
-	frm.set_query('item_code', 'items', () => {
+	frm.set_query("item_code", "items", () => {
 		return {
 			filters: {
 				is_cnp_item: 1,
-				is_sales_item: 1
-			}
-		}
+				is_sales_item: 1,
+			},
+		};
 	});
 }
 
@@ -40,9 +61,9 @@ function set_item_code_query(frm) {
  * Set query for site_engineer
  */
 function set_site_engineer_query(frm) {
-	frm.set_query("site_engineer", function() {
+	frm.set_query("site_engineer", function () {
 		return {
-			query: "stems.stems.custom_scripts.opportunity.opportunity.get_site_engineers"
+			query: "stems.stems.custom_scripts.opportunity.opportunity.get_site_engineers",
 		};
 	});
 }

--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -150,3 +150,64 @@ def get_site_engineers(doctype, txt, searchfield, start, page_len, filters):
     )
 
     return [(d.name, d.employee_name) for d in employees]
+
+@frappe.whitelist()
+def make_boq(source_name, target_doc=None):
+    """
+    Create BOQ from Opportunity
+    - customer_name from lead_name
+    - party_name → lead in BOQ
+    - fetch any Customer Need Profile for this enquiry (draft or submitted)
+    - map items from Opportunity.items → BOQ.items
+      only if item_code exists and qty > 0
+      set BOQ item 'name' = Opportunity 'item_code'
+    """
+
+    def set_missing_values(source, target):
+        # Link Opportunity
+        target.opportunity = source.name
+
+        # Customer name from lead_name
+        if source.lead_name:
+            target.customer_name = source.lead_name
+
+        # Map Opportunity.party_name → BOQ.lead
+        if getattr(source, "party_name", None):
+            target.lead = source.party_name
+
+        # Fetch any Customer Need Profile for this enquiry
+        cnp = frappe.db.get_value(
+            "Customer Need Profile",
+            {"enquiry": source.name},
+            "name",
+            order_by="modified desc"
+        )
+        if cnp:
+            target.customer_need_profile = cnp
+
+        # Map items from Opportunity → BOQ (only if valid)
+        if hasattr(source, "items") and source.items:
+            for row in source.items:
+                if row.item_code and row.qty:
+                    item = target.append("items", {})
+                    item.name = row.item_code       # BOQ item name = item_code
+                    item.item_name = row.item_name
+                    item.qty = row.qty
+                    item.uom = row.uom
+
+    doc = frappe.model.mapper.get_mapped_doc(
+        "Opportunity",
+        source_name,
+        {
+            "Opportunity": {
+                "doctype": "Bill of Quantity",
+                "field_map": {
+                    "name": "opportunity"
+                }
+            }
+        },
+        target_doc,
+        set_missing_values
+    )
+
+    return doc

--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -164,33 +164,26 @@ def make_boq(source_name, target_doc=None):
     """
 
     def set_missing_values(source, target):
-        # Link Opportunity
         target.opportunity = source.name
 
-        # Customer name from lead_name
         if source.lead_name:
             target.customer_name = source.lead_name
 
-        # Map Opportunity.party_name → BOQ.lead
         if getattr(source, "party_name", None):
             target.lead = source.party_name
 
-        # Fetch any Customer Need Profile for this enquiry
-        cnp = frappe.db.get_value(
+        cnp = frappe.db.exists(
             "Customer Need Profile",
-            {"enquiry": source.name},
-            "name",
-            order_by="modified desc"
+            {"enquiry": source.name}
         )
         if cnp:
             target.customer_need_profile = cnp
 
-        # Map items from Opportunity → BOQ (only if valid)
         if hasattr(source, "items") and source.items:
             for row in source.items:
-                if row.item_code and row.qty:
+                if row.item_code and row.qty > 0:
                     item = target.append("items", {})
-                    item.name = row.item_code       # BOQ item name = item_code
+                    item.name = row.item_code
                     item.item_name = row.item_name
                     item.qty = row.qty
                     item.uom = row.uom


### PR DESCRIPTION
## Feature description
Add a new BOQ button on Enquiry to create a Bill of Quantity (BOQ) with automatic mapping of items and lead information

## Analysis and design (optional)
- The BOQ creation workflow maps data from Enquiry to BOQ:

    - customer_name is fetched from lead_name.

    - party_name in Enquiry is mapped to lead in BOQ.

    - Existing Customer Need Profiles linked to the Enquiry are attached automatically.

    - Enquiry items with valid item_code and quantity > 0 are mapped to BOQ.

- BOQ item name is set equal to the Enquiry item_code.

## Solution description
TASK-2026-00017
- Added a custom BOQ button in the Enquiry form.

- Clicking the button opens a mapped BOQ document.

- Mapping logic ensures only valid items are transferred and linked data (like Customer Need Profile) is preserved.

- All item and lead data is synchronized correctly from Enquiry to BOQ.
## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.
<img width="1764" height="813" alt="image" src="https://github.com/user-attachments/assets/a8d4ac15-1ed9-4cf6-8713-80c39f464c2f" />
<img width="1753" height="618" alt="image" src="https://github.com/user-attachments/assets/c64a1be2-237c-4078-9528-0f4f691ac3b6" />

## Areas affected and ensured
Enquiry
Bill of Quantity
## Is there any existing behavior change of other features due to this code change?
No changes to existing features; the functionality is additive.
## Was this feature tested on the browsers?
  - microsoft edge
