### PR TITLE
TASK-2026-00019:Set lead owner from sales person in lead doctype

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -154,7 +154,8 @@ doc_events = {
 		"on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update"
 	},
 	"Lead": {
-		"on_update": "stems.stems.custom_scripts.lead.lead.auto_assign_lead"
+		"on_update": "stems.stems.custom_scripts.lead.lead.auto_assign_lead",
+		"before_save": "stems.stems.custom_scripts.lead.lead.set_owner_from_sales_person",
 	},
 	"Quotation": {
 		"on_update": "stems.stems.custom_scripts.quotation.quotation.send_customer_approval_email"

--- a/stems/stems/custom_scripts/lead/lead.js
+++ b/stems/stems/custom_scripts/lead/lead.js
@@ -1,50 +1,78 @@
 frappe.ui.form.on("Lead", {
-    refresh: function(frm) {
-        setTimeout(() => {
-            customize_lead_buttons(frm);
-        }, 100);
-    },
-    setup: function(frm) {
-        set_sales_person_query(frm);
-    }
+	refresh: function(frm) {
+		setTimeout(() => {
+			customize_lead_buttons(frm);
+		}, 100);
+	},
+	setup: function(frm) {
+		set_sales_person_query(frm);
+	},
+	sales_person: function(frm) {
+		set_lead_owner_from_sales_person(frm);
+	}
+
 });
 
 /*
  * Set query for Sales User
  */
 function set_sales_person_query(frm) {
-    frm.set_query("sales_person", function() {
-        return {
-            query: "stems.stems.custom_scripts.lead.lead.get_sales_user_employees"
-        };
-    });
+	frm.set_query("sales_person", function() {
+		return {
+			query: "stems.stems.custom_scripts.lead.lead.get_sales_user_employees"
+		};
+	});
 }
 
 /*
  * Function to Add and remove custom buttons on Lead form
  */
 function customize_lead_buttons(frm) {
-    frm.remove_custom_button("Opportunity", "Create");
-    frm.remove_custom_button("Prospect", "Create");
-    if (frm.page && frm.page.remove_inner_button) {
-        frm.page.remove_inner_button("Opportunity", "Create");
-        frm.page.remove_inner_button("Prospect", "Create");
-    }
+	frm.remove_custom_button("Opportunity", "Create");
+	frm.remove_custom_button("Prospect", "Create");
+	if (frm.page && frm.page.remove_inner_button) {
+		frm.page.remove_inner_button("Opportunity", "Create");
+		frm.page.remove_inner_button("Prospect", "Create");
+	}
 
-    // Remove Action buttons
-    frm.remove_custom_button("Add to Prospect", "Action");
-    if (frm.page && frm.page.remove_inner_button) {
-        frm.page.remove_inner_button("Add to Prospect", "Action");
-    }
+	// Remove Action buttons
+	frm.remove_custom_button("Add to Prospect", "Action");
+	if (frm.page && frm.page.remove_inner_button) {
+		frm.page.remove_inner_button("Add to Prospect", "Action");
+	}
 
-    // Add Enquiry button under Create group
-    if (!frm.is_new()) {
-        frm.add_custom_button(__('Enquiry'), function() {
-            frappe.model.open_mapped_doc({
-                method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
-                source_name: frm.doc.name
-            });
-        }, __("Create"));
-    }
+	// Add Enquiry button under Create group
+	if (!frm.is_new()) {
+		frm.add_custom_button(__('Enquiry'), function() {
+			frappe.model.open_mapped_doc({
+				method: "stems.stems.custom_scripts.lead.lead.make_enquiry",
+				source_name: frm.doc.name
+			});
+		}, __("Create"));
+	}
 }
 
+/**
+ * Helper function to sync Lead Owner with Sales Person
+ */
+function set_lead_owner_from_sales_person(frm) {
+
+	if (!frm.doc.sales_person) {
+		frm.set_value("lead_owner", frm.doc.owner);
+		return;
+	}
+
+	frappe.db.get_value(
+		"Employee",
+		frm.doc.sales_person,
+		"user_id",
+		function(r) {
+			if (r && r.user_id) {
+				frm.set_value("lead_owner", r.user_id);
+			}
+			else{
+				frm.set_value("lead_owner", null);
+			}
+		}
+	);
+}

--- a/stems/stems/custom_scripts/lead/lead.py
+++ b/stems/stems/custom_scripts/lead/lead.py
@@ -6,123 +6,141 @@ from frappe.desk.form.assign_to import add as add_assignment
 
 @frappe.whitelist()
 def make_enquiry(source_name, target_doc=None):
-    """Create a new Enquiry (Opportunity) from Lead and return Enquiry name"""
+	"""Create a new Enquiry (Opportunity) from Lead and return Enquiry name"""
 
-    if not frappe.db.exists("Lead", source_name):
-        frappe.throw(f"Lead {source_name} not found.")
+	if not frappe.db.exists("Lead", source_name):
+		frappe.throw(f"Lead {source_name} not found.")
 
-    def set_missing_values(source, target):
-        target.opportunity_from = "Lead"
-        target.party_name = source.name
-        target.customer_name = source.lead_name
-        target.contact_email = source.email_id
-        target.contact_mobile = source.phone
+	def set_missing_values(source, target):
+		target.opportunity_from = "Lead"
+		target.party_name = source.name
+		target.customer_name = source.lead_name
+		target.contact_email = source.email_id
+		target.contact_mobile = source.phone
 
-    doc = get_mapped_doc(
-        "Lead",
-        source_name,
-        {
-            "Lead": {
-                "doctype": "Opportunity",
-                "field_map": {
-                    "name": "party_name",
-                    "lead_name": "customer_name",
-                    "email_id": "contact_email",
-                    "phone": "contact_mobile"
-                }
-            }
-        },
-        target_doc,
-        set_missing_values
-    )
-    return doc
+	doc = get_mapped_doc(
+		"Lead",
+		source_name,
+		{
+			"Lead": {
+				"doctype": "Opportunity",
+				"field_map": {
+					"name": "party_name",
+					"lead_name": "customer_name",
+					"email_id": "contact_email",
+					"phone": "contact_mobile"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
+	return doc
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_sales_user_employees(doctype, txt, searchfield, start, page_len, filters):
-    """
-    Fetch employees linked to users with the 'Sales User' role
-    for filtering the Sales Person field in Lead.
-    """
-    users = get_users_with_role("Sales User")
-    if not users:
-        return []
+	"""
+	Fetch employees linked to users with the 'Sales User' role
+	for filtering the Sales Person field in Lead.
+	"""
+	users = get_users_with_role("Sales User")
+	if not users:
+		return []
 
-    employees = frappe.get_all(
-        "Employee",
-        filters={
-            "user_id": ["in", users],
-            searchfield: ["like", f"%{txt}%"]
-        },
-        fields=["name", "employee_name"],
-        start=start,
-        page_length=page_len
-    )
+	employees = frappe.get_all(
+		"Employee",
+		filters={
+			"user_id": ["in", users],
+			searchfield: ["like", f"%{txt}%"]
+		},
+		fields=["name", "employee_name"],
+		start=start,
+		page_length=page_len
+	)
 
-    return [(d.name, d.employee_name) for d in employees]
+	return [(d.name, d.employee_name) for d in employees]
 
 def auto_assign_lead(doc, method=None):
-    """
-    Assign Lead to the User linked to the Employee selected in Sales Person field.
-    Runs on validate (before save). Uses an exist check to ensure assignment only after the Lead exists.
-    """
+	"""
+	Assign Lead to the User linked to the Employee selected in Sales Person field.
+	Runs on validate (before save). Uses an exist check to ensure assignment only after the Lead exists.
+	"""
 
-    # Only assign if Sales Person is selected
-    if not doc.sales_person:
-        return
+	# Only assign if Sales Person is selected
+	if not doc.sales_person:
+		return
 
-    # Check if the Lead exists 
-    if not frappe.db.exists("Lead", doc.name):
-        return
+	# Check if the Lead exists
+	if not frappe.db.exists("Lead", doc.name):
+		return
 
-    employee = doc.sales_person
-    user_id = frappe.db.get_value("Employee", employee, "user_id")
+	employee = doc.sales_person
+	user_id = frappe.db.get_value("Employee", employee, "user_id")
 
-    if not user_id:
-        return
+	if not user_id:
+		return
 
-    # Check if a ToDo already exists for this Lead assigned to this user
-    todo_exists = frappe.db.exists(
-        "ToDo",
-        {
-            "reference_type": "Lead",
-            "reference_name": doc.name,
-            "owner": user_id,
-            "status": "Open"
-        }
-    )
+	# Check if a ToDo already exists for this Lead assigned to this user
+	todo_exists = frappe.db.exists(
+		"ToDo",
+		{
+			"reference_type": "Lead",
+			"reference_name": doc.name,
+			"owner": user_id,
+			"status": "Open"
+		}
+	)
 
-    if todo_exists:
-        return
+	if todo_exists:
+		return
 
-    # Create new assignment
-    add_assignment({
-        "assign_to": [user_id],
-        "doctype": "Lead",
-        "name": doc.name,
-        "description": f"Auto-assigned Lead {doc.name} to {user_id}",
-        "assigned_by": frappe.session.user
-    })
+	# Create new assignment
+	add_assignment({
+		"assign_to": [user_id],
+		"doctype": "Lead",
+		"name": doc.name,
+		"description": f"Auto-assigned Lead {doc.name} to {user_id}",
+		"assigned_by": frappe.session.user
+	})
 
 @frappe.whitelist()
 def bulk_assign_lead(docnames, sales_user):
-    """
-    Assign multiple Leads to the given Sales User
-    docnames: list of Lead names as JSON string
-    sales_user: Employee name
-    """
-    docnames = json.loads(docnames)  # Convert JSON string to list
-    assigned = []
+	"""
+	Assign multiple Leads to the given Sales User
+	docnames: list of Lead names as JSON string
+	sales_user: Employee name
+	"""
+	docnames = json.loads(docnames)  # Convert JSON string to list
+	assigned = []
 
-    for docname in docnames:
-        try:
-            lead = frappe.get_doc("Lead", docname)
-            # Set sales person (assuming fieldname is 'sales_person')
-            lead.sales_person = sales_user
-            lead.save()
-            frappe.db.commit()
-            assigned.append(docname)
-        except Exception as e:
-            frappe.log_error(message=str(e), title="Auto Assign Lead Error")
+	for docname in docnames:
+		try:
+			lead = frappe.get_doc("Lead", docname)
+			# Set sales person (assuming fieldname is 'sales_person')
+			lead.sales_person = sales_user
+			lead.save()
+			frappe.db.commit()
+			assigned.append(docname)
+		except Exception as e:
+			frappe.log_error(message=str(e), title="Auto Assign Lead Error")
 
-    return {"assigned": assigned, "sales_user": sales_user}
+	return {"assigned": assigned, "sales_user": sales_user}
+
+def set_owner_from_sales_person(doc, method=None):
+	"""
+	Set system owner and lead_owner from Sales Person
+	"""
+
+	if not doc.sales_person:
+		return
+
+	user_id = frappe.db.get_value(
+		"Employee",
+		doc.sales_person,
+		"user_id"
+	)
+
+	if user_id:
+		doc.lead_owner = user_id
+


### PR DESCRIPTION
## Feature description
Need to: Set lead owner from sales person in lead doctype

## Solution description

- When a Sales Person is selected:
   - Fetch the user_id from the linked Employee record.
   - Automatically update the lead_owner field.
- When the Sales Person is cleared:
    - Reset lead_owner to the document creator (owner) or clear it if no user is linked.
    - The system owner field (owner) is not modified in JavaScript.
- Provides immediate UI feedback without requiring save or refresh.
- A server-side hook is added to the Lead doctype using the before_save event.

## Output screenshots (optional)
[Screencast from 05-01-26 01:41:14 PM IST.webm](https://github.com/user-attachments/assets/13470687-6455-4298-8317-99e73564c761)

## Areas affected and ensured
Lead doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
 
