### PR TITLE
TASK-2026-00029 : add Sketch table shown when Drawing Required is enabled

### DIFF
--- a/stems/custom/custom_field/opportunity.py
+++ b/stems/custom/custom_field/opportunity.py
@@ -43,10 +43,10 @@ def get_opportunity_custom_fields():
 				"read_only": 1
 			},
             {
-			"fieldname": "sketch_section",
-			"label": "Sketch",
-			"fieldtype": "Section Break",
-			"insert_after": "probability",
+				"fieldname": "sketch_section",
+				"label": "Sketch",
+				"fieldtype": "Section Break",
+				"insert_after": "probability",
 		    },
 			{
 				"fieldname": "sketch_table",

--- a/stems/custom/custom_field/opportunity.py
+++ b/stems/custom/custom_field/opportunity.py
@@ -42,5 +42,20 @@ def get_opportunity_custom_fields():
 				"fetch_from": "lead.lead_name",
 				"read_only": 1
 			},
+            {
+			"fieldname": "sketch_section",
+			"label": "Sketch",
+			"fieldtype": "Section Break",
+			"insert_after": "probability",
+		    },
+			{
+				"fieldname": "sketch_table",
+				"label": "Sketch Table",
+				"fieldtype": "Table",
+				"options": "Sketch",
+				"insert_after": "sketch_section",
+				"depends_on": "eval:doc.drawing_required",
+			},
+
 		]
 	}

--- a/stems/stems/doctype/sketch/sketch.json
+++ b/stems/stems/doctype/sketch/sketch.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-05 12:13:30.182897",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "description",
+  "sketch_file"
+ ],
+ "fields": [
+  {
+   "fieldname": "description",
+   "fieldtype": "Long Text",
+   "in_list_view": 1,
+   "label": "Description"
+  },
+  {
+   "fieldname": "sketch_file",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Sketch File"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-05 12:16:19.969936",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Sketch",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/sketch/sketch.py
+++ b/stems/stems/doctype/sketch/sketch.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Sketch(Document):
+	pass


### PR DESCRIPTION
## Feature description
Added a Sketch Table to the Opportunity form that allows users to upload sketch/drawing files along with a description. The table is displayed only when “Drawing Required” is enabled
## Analysis and design (optional)
-  Requirement was to capture sketches/drawings only when needed
-  Used a conditional table field controlled by the Drawing Required checkbox.
-  Implemented a Section Break to ensure the table spans the full width of the page and is positioned correctly in the form layout.
## Solution description
- Added a Sketch Table field to the Opportunity DocType.
- Created a child DocType (Sketch) with:
  - Description field
  - File upload field supporting all file types
- Configured the table to appear below Status and above the Organization section.
Applied depends_on logic so the table is visible only when Drawing Required is checked
## Output screenshots (optional)
<img width="1660" height="790" alt="image" src="https://github.com/user-attachments/assets/d1a93115-22e1-4bf4-91eb-da1dbad9d5e0" />
<img width="1638" height="895" alt="image" src="https://github.com/user-attachments/assets/a1123184-a8cc-4ff7-bd8b-a24e089d0661" />

## Areas affected and ensured
- Opportunity DocType (form layout and fields)
- Child DocType: Sketch
- Conditional UI rendering based on Drawing Required
## Is there any existing behavior change of other features due to this code change?
no
## Was this feature tested on the browsers?
  - microsoft edge
