### PR TITLE
fix: UOM is not fetched for item in Bill of quantity

### DIFF
--- a/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
+++ b/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
@@ -34,6 +34,7 @@
    "label": "Qty"
   },
   {
+   "fetch_from": "item.stock_uom",
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -45,7 +46,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-09-03 11:37:55.994283",
+ "modified": "2026-01-05 16:35:56.179287",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity Item",


### PR DESCRIPTION
## Issue description
1. UOM is not fetched for item in Bill of Quantity doctype

## Solution description

1. Need to add fetch from for the Uom field in the Bill of quantity item child table 
2. selected item doctype as fetch from and select field default unit of measure in item doctype

## Output screenshots (optional)

[Screencast from 05-01-26 04:44:28 PM IST.webm](https://github.com/user-attachments/assets/8b525236-71b1-4024-af74-599687785b0c)

## Areas affected and ensured
Bill of Quantity Item and Bill of Quantity doctype 

## Is there any existing behavior change of other features due to this code change?
No
## Was this feature tested on the browsers?

  - Mozilla Firefox
  
