### PR TITLE
TASK-2026-00020:Update Lead qualification status  on Enquiry creation

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -151,7 +151,8 @@ before_uninstall = "stems.install.before_uninstall"
 
 doc_events = {
 	"Opportunity": {
-		"on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update"
+		"on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update",
+		"after_insert": "stems.stems.custom_scripts.opportunity.opportunity.update_lead_qualification_status",
 	},
 	"Lead": {
 		"on_update": "stems.stems.custom_scripts.lead.lead.auto_assign_lead"

--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -3,7 +3,6 @@ from frappe.model.document import Document
 from frappe.desk.form.assign_to import add as add_assign
 from frappe.utils.user import get_users_with_role
 
-
 def on_update(doc, method=None):
 	"""
 	Triggered on Opportunity update.
@@ -204,3 +203,33 @@ def make_boq(source_name, target_doc=None):
     )
 
     return doc
+
+def update_lead_qualification_status(doc, method=None):
+    """
+    Update Lead qualification status when Opportunity is created from Lead
+    """
+
+    if doc.opportunity_from != "Lead":
+        return
+
+    lead_name = doc.party_name
+    if not lead_name:
+        return
+
+    if not frappe.db.exists("Lead", lead_name):
+        return
+
+    current_status = frappe.db.get_value(
+        "Lead",
+        lead_name,
+        "qualification_status"
+    )
+
+    if current_status != "Qualified":
+        frappe.db.set_value(
+            "Lead",
+            lead_name,
+            "qualification_status",
+            "Qualified"
+        )
+


### PR DESCRIPTION
## Feature description
Need to: Update Lead qualification status  on Enquiry creation

## Solution description
 Update Lead qualification status  is qualified when  Enquiry  is created from lead 

## Output screenshots (optional)
[Screencast from 06-01-26 12:16:25 PM IST.webm](https://github.com/user-attachments/assets/16d6bd9d-387c-4a94-aca4-d4c5953c8445)


## Areas affected and ensured
Lead doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

