### PR TITLE
fix: multiple events from being created for a single opportunity

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -45,7 +45,7 @@ def create_site_visit_event(doc):
 
 	existing_event = frappe.db.exists({
 		"doctype": "Event",
-		"reference_type": "Opportunity",
+		"reference_doctype": "Opportunity",
 		"reference_name": doc.name,
 		"subject": ["like", f"Site Visit - {party}%"]
 	})
@@ -56,7 +56,7 @@ def create_site_visit_event(doc):
 	event.subject = f"Site Visit - {party}"
 	event.event_type = "Private"
 	event.starts_on = doc.site_visit_scheduled_on
-	event.reference_type = "Opportunity"
+	event.reference_doctype = "Opportunity"
 	event.reference_name = doc.name
 	event.status = "Open"
 
@@ -68,10 +68,10 @@ def create_site_visit_event(doc):
 		participant.reference_doctype = "Employee"
 		participant.reference_docname = doc.site_engineer
 
-	if doc.opportunity_owner:
-		participant = event.append("event_participants", {})
-		participant.reference_doctype = "Opportunity"
-		participant.reference_docname = doc.name
+
+	participant = event.append("event_participants", {})
+	participant.reference_doctype = "Opportunity"
+	participant.reference_docname = doc.name
 
 	if doc.opportunity_from:
 		participant = event.append("event_participants", {})
@@ -183,7 +183,7 @@ def make_boq(source_name, target_doc=None):
             for row in source.items:
                 if row.item_code and row.qty > 0:
                     item = target.append("items", {})
-                    item.name = row.item_code
+                    item.item = row.item_code
                     item.item_name = row.item_name
                     item.qty = row.qty
                     item.uom = row.uom


### PR DESCRIPTION
## Issue  description
TASK-2026-00036
1. Need to prevents  multiple events from being created for a  opportunity   doctype 
2.  Events is not created for the opportunity 
3. when creating bill of Quandity from enquiry it is not saving because the item code is not fetched properly 

## Solution description

1.  Duplicate check is used wrong field as reference field 
2. Removed the unwanted condition where the opportunity owner was required to create an event from the Opportunity doctype.
3. BOQ items were incorrectly assigned to name instead of item.
- Assign item_code to the item field to fix the mapping.

## Output screenshots (optional)
[Screencast from 06-01-26 03:47:02 PM IST.webm](https://github.com/user-attachments/assets/47b81402-f96a-4131-87eb-24a3eee44ba5)
[Screencast from 06-01-26 03:47:54 PM IST.webm](https://github.com/user-attachments/assets/4f2eb099-1f86-402e-a56d-26e8a44c0d0e)

## Areas affected and ensured
Opportunity doctype and bill of Quantity doctype 
## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Mozilla firefox