### PR TITLE
TASK-2026-00038:Allow custom title based naming with fallback to naming series

### DIFF
--- a/stems/custom/custom_field/opportunity.py
+++ b/stems/custom/custom_field/opportunity.py
@@ -42,5 +42,27 @@ def get_opportunity_custom_fields():
 				"fetch_from": "lead.lead_name",
 				"read_only": 1
 			},
+            {
+				"fieldname": "sketch_section",
+				"label": "Sketch",
+				"fieldtype": "Section Break",
+				"insert_after": "probability",
+		    },
+			{
+				"fieldname": "sketch_table",
+				"label": "Sketch Table",
+				"fieldtype": "Table",
+				"options": "Sketch",
+				"insert_after": "sketch_section",
+				"depends_on": "eval:doc.drawing_required",
+			},
+			{
+				"fieldname": "opportunity_name",
+				"label": "Opportunity Name",
+				"fieldtype": "Data",
+				"insert_after": "opportunity_from",
+				"is_title_field": 1,
+				"unique": 1,
+			},
 		]
 	}

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -153,6 +153,8 @@ doc_events = {
 	"Opportunity": {
 		"on_update": "stems.stems.custom_scripts.opportunity.opportunity.on_update",
 		"after_insert": "stems.stems.custom_scripts.opportunity.opportunity.update_lead_qualification_status",
+		"before_insert": "stems.stems.custom_scripts.opportunity.opportunity.before_insert_opportunity",
+		"before_save": "stems.stems.custom_scripts.opportunity.opportunity.before_save_opportunity",
 	},
 	"Lead": {
 		"on_update": "stems.stems.custom_scripts.lead.lead.auto_assign_lead",

--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -20,7 +20,7 @@ def on_update(doc, method=None):
 	if doc.site_visit_required and doc.site_visit_scheduled_on:
 		create_site_visit_event(doc)
 		create_site_visit_todo(doc)
-
+	sync_opportunity_title(doc)
 
 def create_site_visit_event(doc):
 	"""
@@ -129,107 +129,159 @@ def create_site_visit_todo(doc):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_site_engineers(doctype, txt, searchfield, start, page_len, filters):
-    """
-    Fetch employees linked to users with the 'Site Engineer' role
-    for Link field searches.
-    """
-    users = get_users_with_role("Site Engineer")
-    if not users:
-        return []
+	"""
+	Fetch employees linked to users with the 'Site Engineer' role
+	for Link field searches.
+	"""
+	users = get_users_with_role("Site Engineer")
+	if not users:
+		return []
 
-    employees = frappe.get_all(
-        "Employee",
-        filters={
-            "user_id": ["in", users],
-            searchfield: ["like", f"%{txt}%"]
-        },
-        fields=["name", "employee_name"],
-        start=start,
-        page_length=page_len
-    )
+	employees = frappe.get_all(
+		"Employee",
+		filters={
+			"user_id": ["in", users],
+			searchfield: ["like", f"%{txt}%"]
+		},
+		fields=["name", "employee_name"],
+		start=start,
+		page_length=page_len
+	)
 
-    return [(d.name, d.employee_name) for d in employees]
+	return [(d.name, d.employee_name) for d in employees]
 
 @frappe.whitelist()
 def make_boq(source_name, target_doc=None):
-    """
-    Create BOQ from Opportunity
-    - customer_name from lead_name
-    - party_name → lead in BOQ
-    - fetch any Customer Need Profile for this enquiry (draft or submitted)
-    - map items from Opportunity.items → BOQ.items
-      only if item_code exists and qty > 0
-      set BOQ item 'name' = Opportunity 'item_code'
-    """
+	"""
+	Create BOQ from Opportunity
+	- customer_name from lead_name
+	- party_name → lead in BOQ
+	- fetch any Customer Need Profile for this enquiry (draft or submitted)
+	- map items from Opportunity.items → BOQ.items
+	  only if item_code exists and qty > 0
+	  set BOQ item 'name' = Opportunity 'item_code'
+	"""
 
-    def set_missing_values(source, target):
-        target.opportunity = source.name
+	def set_missing_values(source, target):
+		target.opportunity = source.name
 
-        if source.lead_name:
-            target.customer_name = source.lead_name
+		if source.lead_name:
+			target.customer_name = source.lead_name
 
-        if getattr(source, "party_name", None):
-            target.lead = source.party_name
+		if getattr(source, "party_name", None):
+			target.lead = source.party_name
 
-        cnp = frappe.db.exists(
-            "Customer Need Profile",
-            {"enquiry": source.name}
-        )
-        if cnp:
-            target.customer_need_profile = cnp
+		cnp = frappe.db.exists(
+			"Customer Need Profile",
+			{"enquiry": source.name}
+		)
+		if cnp:
+			target.customer_need_profile = cnp
 
-        if hasattr(source, "items") and source.items:
-            for row in source.items:
-                if row.item_code and row.qty > 0:
-                    item = target.append("items", {})
-                    item.item = row.item_code
-                    item.item_name = row.item_name
-                    item.qty = row.qty
-                    item.uom = row.uom
+		if hasattr(source, "items") and source.items:
+			for row in source.items:
+				if row.item_code and row.qty > 0:
+					item = target.append("items", {})
+					item.item = row.item_code
+					item.item_name = row.item_name
+					item.qty = row.qty
+					item.uom = row.uom
 
-    doc = frappe.model.mapper.get_mapped_doc(
-        "Opportunity",
-        source_name,
-        {
-            "Opportunity": {
-                "doctype": "Bill of Quantity",
-                "field_map": {
-                    "name": "opportunity"
-                }
-            }
-        },
-        target_doc,
-        set_missing_values
-    )
+	doc = frappe.model.mapper.get_mapped_doc(
+		"Opportunity",
+		source_name,
+		{
+			"Opportunity": {
+				"doctype": "Bill of Quantity",
+				"field_map": {
+					"name": "opportunity"
+				}
+			}
+		},
+		target_doc,
+		set_missing_values
+	)
 
-    return doc
+	return doc
 
 def update_lead_qualification_status(doc, method=None):
-    """
-    Update Lead qualification status when Opportunity is created from Lead
-    """
+	"""
+	Update Lead qualification status when Opportunity is created from Lead
+	"""
 
-    if doc.opportunity_from != "Lead":
-        return
+	if doc.opportunity_from != "Lead":
+		return
 
-    lead_name = doc.party_name
-    if not lead_name:
-        return
+	lead_name = doc.party_name
+	if not lead_name:
+		return
 
-    if not frappe.db.exists("Lead", lead_name):
-        return
+	if not frappe.db.exists("Lead", lead_name):
+		return
 
-    current_status = frappe.db.get_value(
-        "Lead",
-        lead_name,
-        "qualification_status"
-    )
+	current_status = frappe.db.get_value(
+		"Lead",
+		lead_name,
+		"qualification_status"
+	)
 
-    if current_status != "Qualified":
-        frappe.db.set_value(
-            "Lead",
-            lead_name,
-            "qualification_status",
-            "Qualified"
-        )
+	if current_status != "Qualified":
+		frappe.db.set_value(
+			"Lead",
+			lead_name,
+			"qualification_status",
+			"Qualified"
+		)
 
+def before_insert_opportunity(doc, method=None):
+	"""
+	Naming & uniqueness logic:
+	- Same Lead → Opportunity Name must be unique
+	- Different Lead → Same Opportunity Name allowed
+	- If opportunity_name is empty → use naming series
+	"""
+
+	if not doc.opportunity_name:
+		return
+
+	lead = doc.party_name or doc.lead_name
+	if not lead:
+		frappe.throw("Lead is required to validate Opportunity Name")
+
+	doc.name = doc.opportunity_name
+
+def before_save_opportunity(doc, method=None):
+	"""
+	Ensure title is always populated:
+	- If opportunity_name exists → title = opportunity_name
+	- Else → title = document ID (name)
+	"""
+
+	if doc.opportunity_name:
+		doc.title = doc.opportunity_name
+	else:
+		doc.title = doc.name
+
+def sync_opportunity_title(doc, method=None):
+	'''
+		Sync Opportunity title with opportunity_name if provided; otherwise, sync with the document ID (name).
+		This ensures the title always reflects the intended display name, updating on save/insert.
+	'''
+	if doc.opportunity_name:
+		if doc.title != doc.opportunity_name:
+			frappe.db.set_value(
+				"Opportunity",
+				doc.name,
+				"title",
+				doc.opportunity_name,
+				update_modified=False
+			)
+	else:
+		if doc.title != doc.name:
+			frappe.db.set_value(
+				"Opportunity",
+				doc.name,
+				"title",
+				doc.name,
+				update_modified=False
+			)

--- a/stems/stems/doctype/sketch/sketch.json
+++ b/stems/stems/doctype/sketch/sketch.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-05 12:13:30.182897",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "description",
+  "sketch_file"
+ ],
+ "fields": [
+  {
+   "fieldname": "description",
+   "fieldtype": "Long Text",
+   "in_list_view": 1,
+   "label": "Description"
+  },
+  {
+   "fieldname": "sketch_file",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Sketch File"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-05 12:16:19.969936",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Sketch",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/sketch/sketch.py
+++ b/stems/stems/doctype/sketch/sketch.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class Sketch(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to: 

- Add a field:
      Opportunity Name (Data)
- Set Opportunity Name field as title field
- If the field is empty before insert/save fill in with Opportunity ID

## Solution description
- Introduced a new data field "Opportunity Name" and configured it as the title field.
- Added before_insert validation to:
  - Set document name from Opportunity Name when provided.
  - Allow default naming series when the field is empty.
- Enforced uniqueness when using custom titles to avoid duplicate document IDs.

## Output screenshots (optional)

[Screencast from 07-01-26 09:54:39 AM IST.webm](https://github.com/user-attachments/assets/b2703d03-f11a-4f6e-9508-563d544cb070)

## Areas affected and ensured

Enquiry doctype

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome

