### PR TITLE
TASK-2026-00021: Notify participants on Site Visit Event creation

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -56,7 +56,7 @@ def create_site_visit_event(doc):
 	event.event_type = "Private"
 	event.starts_on = doc.site_visit_scheduled_on
 	event.reference_doctype = "Opportunity"
-	event.reference_name = doc.name
+	event.reference_docname = doc.name
 	event.status = "Open"
 
 	event.insert(ignore_permissions=True)
@@ -84,7 +84,78 @@ def create_site_visit_event(doc):
 			participant.reference_docname = linked_docname
 
 	event.save(ignore_permissions=True)
+	send_event_notification(event, doc)
 
+def send_event_notification(event, opportunity):
+	"""
+	Send email notification to all participants of a Site Visit Event.
+	"""
+	template_name = frappe.db.get_single_value("STEMS Settings", "event_email_template")
+	if not template_name:
+		frappe.log_error(frappe.get_traceback(), "Event Email Template Missing in STEMS Settings")
+		return
+
+	recipients = set()
+	for p in event.event_participants:
+		if p.reference_doctype == "Employee":
+			email = frappe.db.get_value(
+				"Employee", p.reference_docname, "prefered_email"
+			)
+			if not email:
+				user_id = frappe.db.get_value(
+					"Employee", p.reference_docname, "user_id"
+				)
+				if user_id:
+					email = frappe.db.get_value("User", user_id, "email")
+			if email:
+				recipients.add(email)
+		elif p.reference_doctype == "Opportunity":
+			email = frappe.db.get_value(
+				"Opportunity",
+				p.reference_docname,
+				"contact_email"
+			)
+			if email:
+				recipients.add(email)
+		elif p.reference_doctype == "Customer":
+			result = frappe.db.sql("""
+				SELECT
+					COALESCE(ce.email_id, c.email_id) AS email
+				FROM `tabContact` c
+				INNER JOIN `tabDynamic Link` dl
+					ON dl.parent = c.name
+				LEFT JOIN `tabContact Email` ce
+					ON ce.parent = c.name
+				   AND ce.is_primary = 1
+				WHERE dl.link_doctype = 'Customer'
+				  AND dl.link_name = %s
+				  AND (ce.email_id IS NOT NULL OR c.email_id IS NOT NULL)
+				LIMIT 1
+			""", p.reference_docname, as_dict=True)
+
+			if result and result[0].email:
+				recipients.add(result[0].email)
+
+	if not recipients:
+		frappe.log_error(frappe.get_traceback(),f"No recipients for {event.name}")
+		return
+
+	template = frappe.get_doc("Email Template", template_name)
+	context = {
+		"event": event,
+		"opportunity": opportunity,
+		"party_name": opportunity.party_name,
+		"starts_on": event.starts_on,
+	}
+	subject = frappe.render_template(template.subject, context)
+	message = frappe.render_template(template.response, context)
+	frappe.sendmail(
+		recipients=list(recipients),
+		subject=subject,
+		message=message,
+		reference_doctype="Event",
+		reference_name=event.name,
+	)
 
 def create_site_visit_todo(doc):
 	"""

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -8,6 +8,8 @@
   "notification_settings_section",
   "enable_quotation_approval_notifcation",
   "quotation_approval_notifcation_template",
+  "enable_opportunity_activity_notification",
+  "event_email_template",
   "column_break_zbaj",
   "quotation_print_format"
  ],
@@ -44,13 +46,27 @@
   {
    "fieldname": "column_break_zbaj",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_opportunity_activity_notification",
+   "fieldtype": "Check",
+   "label": "Enable Opportunity Activity Notification"
+  },
+  {
+   "depends_on": "eval:doc.enable_opportunity_activity_notification",
+   "description": "Email Template used to notify participants when a Site Visit Event is created.",
+   "fieldname": "event_email_template",
+   "fieldtype": "Link",
+   "label": "Site Visit Notification Template",
+   "options": "Email Template"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-04 10:08:52.939497",
+ "modified": "2026-01-08 11:53:27.804468",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "STEMS Settings",


### PR DESCRIPTION
## Feature description
send email notifications to all participants when a Site Visit Event is created from an Opportunity. Participants include linked Employees, Opportunity contact, and Customer primary contact. The email template is configurable via STEMS Settings (event_email_template).
## Analysis and design (optional)
- When an Opportunity has a scheduled Site Visit, an Event is created (create_site_visit_event).
- Participants are added to the Event: Employee, Opportunity, Customer/Lead.
- A notification email should be sent after Event creation.
- Emails are gathered dynamically based on participant type, and the template renders context variables like event.subject, opportunity.party_name, and event.starts_on.
- Error logging is included for missing templates or recipients to facilitate debugging.

## Solution description
- Added send_event_notification(event, opportunity) function inside opportunity.py to handle:
  - Collecting recipient emails
  - Rendering the email using the configured template
  - Sending the email via frappe.sendmail
- Updated create_site_visit_event to call send_event_notification after the Event is saved.
- Added event_email_template field in STEMS Settings to select the template for notifications.
- Logs errors when the template is missing or no recipients are found.
## Output screenshots (optional)
<img width="1230" height="885" alt="image" src="https://github.com/user-attachments/assets/a4cb6796-e7fc-4b2b-bbc4-d66914055204" />
<img width="1061" height="523" alt="image" src="https://github.com/user-attachments/assets/b8693e90-a9c6-46c8-807c-6f84046f7788" />
<img width="1416" height="885" alt="image" src="https://github.com/user-attachments/assets/e27905cc-f730-4b67-8b06-f6ff2edd182a" />
## Areas affected and ensured
- Opportunity: Event creation workflow
- Event: participant email notification
- STEMS Settings: added new field for template selection
- Email sending logic: new backend function send_event_notification

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
