### PR TITLE
TASK-2026-00021: send site event emails to lead participants

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -135,6 +135,10 @@ def send_event_notification(event, opportunity):
 
 			if result and result[0].email:
 				recipients.add(result[0].email)
+		elif p.reference_doctype == "Lead":
+			email = frappe.db.get_value("Lead", p.reference_docname, "email_id")
+			if email:
+				recipients.add(email)
 
 	if not recipients:
 		frappe.log_error(frappe.get_traceback(),f"No recipients for {event.name}")


### PR DESCRIPTION
## Feature description
Initially, site visit event email notifications were not sent to Lead participants when the enquiry party was a Lead.
## Analysis and design (optional)
The event notification logic was updated to handle Lead as a valid event participant type. When a Lead is added as a participant, the system now retrieves the email address from the email_id field of the Lead record and includes it in the event notification recipient list.
## Solution description
Describe your code changes in detail for reviewers.

## Output screenshots (optional)
Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
- Event email notification logic
- Opportunity custom script
- Event participant handling for Lead doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
