### PR TITLE
feat: Notify the sales person for follow-up for Quotation

### DIFF
--- a/stems/custom/custom_field/quotation.py
+++ b/stems/custom/custom_field/quotation.py
@@ -18,5 +18,13 @@ def get_quotation_custom_fields():
 				"label": "Required Items",
 				"insert_after": "items",
 			},
+			{
+				"fieldname": "sales_person",
+				"fieldtype": "Link",
+				"options": "Employee",
+				"label": "Sales Person",
+				"insert_after": "valid_till",
+			},
+			
 		]
 	}

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -166,13 +166,13 @@ doc_events = {
 # Scheduled Tasks
 # ---------------
 
-# scheduler_events = {
+scheduler_events = {
 # 	"all": [
 # 		"stems.tasks.all"
 # 	],
-# 	"daily": [
-# 		"stems.tasks.daily"
-# 	],
+	"daily": [
+		 "stems.stems.custom_scripts.quotation.quotation.follow_up_notification"
+	],
 # 	"hourly": [
 # 		"stems.tasks.hourly"
 # 	],
@@ -182,7 +182,7 @@ doc_events = {
 # 	"monthly": [
 # 		"stems.tasks.monthly"
 # 	],
-# }
+ }
 
 # Testing
 # -------

--- a/stems/stems/custom_scripts/quotation/quotation.py
+++ b/stems/stems/custom_scripts/quotation/quotation.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.model.mapper import get_mapped_doc
 from frappe.email.doctype.email_template.email_template import get_email_template
-from frappe.utils import getdate, nowdate
+from frappe.utils import getdate, nowdate , add_days
 from frappe import _
 from erpnext.selling.doctype.quotation.quotation import _make_customer, get_ordered_items
 
@@ -135,3 +135,42 @@ def send_customer_approval_email(doc, method=None):
         reference_name=doc.name,
         attachments=attachments
     )
+
+
+def follow_up_notification():
+	"""
+	Send an follow-up notification to the Sales Person
+	if a Quotation remains in Draft beyond the configured
+	follow-up days in STEMS Settings.
+	"""
+	settings = frappe.get_single("STEMS Settings")
+	if not settings.follow_up_days or not settings.follow_up_notification_template:
+		return
+	follow_up_days = int(settings.follow_up_days)
+	today = getdate(nowdate())
+	quotations = frappe.get_all(
+		"Quotation",
+		filters={"docstatus": 0},
+		fields=["name", "transaction_date", "sales_person"]
+	)
+	for q in quotations:
+		if not q.transaction_date or not q.sales_person:
+			continue
+		transaction_date = getdate(q.transaction_date)
+		follow_up_trigger_date = add_days(transaction_date, follow_up_days)
+		if today < follow_up_trigger_date:
+			continue
+		user = frappe.db.get_value("Employee", q.sales_person, "user_id")
+		if not user:
+			continue
+		message = settings.follow_up_notification_template.format(
+			quotation=q.name
+		)
+		frappe.get_doc({
+			"doctype": "Notification Log",
+			"subject": "Quotation Follow-up Required",
+			"email_content": message,
+			"for_user": user,
+			"document_type": "Quotation",
+			"document_name": q.name
+		}).insert(ignore_permissions=True)

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -8,10 +8,13 @@
   "notification_settings_section",
   "enable_quotation_approval_notifcation",
   "quotation_approval_notifcation_template",
-  "enable_opportunity_activity_notification",
-  "event_email_template",
+  "enable_quotation_follow_up",
+  "follow_up_notification_template",
+  "follow_up_days",
   "column_break_zbaj",
-  "quotation_print_format"
+  "quotation_print_format",
+  "enable_opportunity_activity_notification",
+  "event_email_template"
  ],
  "fields": [
   {
@@ -60,13 +63,34 @@
    "fieldtype": "Link",
    "label": "Site Visit Notification Template",
    "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.enable_quotation_follow_up",
+   "description": "Email Template used to notify the Sales Person for submit the Quotation.",
+   "fieldname": "follow_up_notification_template",
+   "fieldtype": "Link",
+   "label": " Quotation Follow up notification template ",
+   "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.enable_quotation_follow_up",
+   "description": "No. of days after quotation creation used to notify the Sales Person.",
+   "fieldname": "follow_up_days",
+   "fieldtype": "Int",
+   "label": " Follow Up Days for Quotation"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_quotation_follow_up",
+   "fieldtype": "Check",
+   "label": "Enable Quotation Follow Up Notification"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-08 11:53:27.804468",
+ "modified": "2026-01-09 16:44:20.046322",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "STEMS Settings",


### PR DESCRIPTION
## Feature description
TASK-2026-00043
1. need to add field in quotation sales person( link- employee)
2. need to add fields stems settings 
3. Implement  functionality to notify the Sales Person when a Quotation remains in Draft beyond the configured follow-up days .

## Solution description
 1. customized the quotation doctype added field sales person(link- employee)
 2. added fields in STEMS  Settings
 -Enable Quotation Follow Up Notification (checkbox)
- Quotation Follow up notification template (link-email template)] -description(Email Template used to notify the Sales Person for submit the Quotation)
- Follow Up Days for Quotation(int)-description(No. of days after quotation creation used to notify the Sales Person.)
3. Notify  to Sales Persons to follow up on Draft Quotations after the configured number of days. in stem setting via scheduler event 
## Output screenshots (optional)
[Screencast from 09-01-26 05:19:25 PM IST.webm](https://github.com/user-attachments/assets/4d95f41d-3405-4dd1-8a1d-58bb01db91f2)
<img width="1874" height="972" alt="image" src="https://github.com/user-attachments/assets/883a0548-9226-4df0-80fa-7913bccae0db" />
<img width="1874" height="972" alt="image" src="https://github.com/user-attachments/assets/c1f5ce8e-4878-4866-9759-3833957440bc" />


## Areas affected and ensured
quotation and stem settings doctype

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  