### PR TITLE
TASK-2026-00076: match billing type option with CNP

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
@@ -60,13 +60,13 @@
    "fieldname": "billing_type",
    "fieldtype": "Select",
    "label": "Billing Type",
-   "options": "\nService Only\nItem and Service"
+   "options": "\nService Only\nItems and Service"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-07 17:27:12.786748",
+ "modified": "2026-01-13 11:31:34.375990",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity",


### PR DESCRIPTION
## Feature description
Fix the BOQ creation validation error by aligning the Billing Type select options in Bill of Quantity with the value passed from Customer Need Profile (CNP). This ensures BOQs can be created successfully when the billing type is “Items and Service”.
## Analysis and design (optional)
- The BOQ billing_type field is a Select field with strict value validation.
- CNP passes the value “Items and Service”, but BOQ previously allowed only “Item and Service”.
- This mismatch caused Frappe’s _validate_selects() to throw a ValidationError.

## Solution description
- Updated the Billing Type select options in Bill of Quantity DocType:
  - Changed option from Item and Service → Items and Service
- This ensures the value copied from CNP is accepted during BOQ save.
- No backend or client-side logic changes were required.
## Output screenshots (optional)
BOQ successfully saved when created from a CNP with Billing Type = Items and Service
[Screencast from 01-13-2026 11:45:05 AM.webm](https://github.com/user-attachments/assets/80b6468c-fcea-4f59-8dbb-92b0255fc025)

## Areas affected and ensured
- DocType: Bill of Quantity
  - Field: billing_type
-  Ensured:
  - Consistent billing type values between CNP and BOQ
  - Successful BOQ creation from CNP
  - No impact on existing billing types like Service Only
## Is there any existing behavior change of other features due to this code change?
No.
## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
