### PR TITLE
feat: Add the item description field in Bill of quantity item doctype

### DIFF
--- a/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
+++ b/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
@@ -10,7 +10,8 @@
   "item_name",
   "qty",
   "uom",
-  "customer_provided"
+  "customer_provided",
+  "description"
  ],
  "fields": [
   {
@@ -48,13 +49,20 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Customer Provided"
+  },
+  {
+   "fetch_from": "item.description",
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Description"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-09 14:47:59.581252",
+ "modified": "2026-01-13 11:48:01.641289",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity Item",


### PR DESCRIPTION
## Feature description
TASK-2026-00074
1. Need To Add a field in the description (small text)  in bill of quantity item child table doctype 
2. Need to set the description when selecting the item in items child table in bill of quantity doctype

## Solution description
1. Added the field description field in the bill of quantity item child  table doctype
2. add fetch from to field description in the bill of quantity item child table 
 - selecting the description field  in the item doctype
## Output screenshots (optional)
[Screencast from 13-01-26 12:57:13 PM IST.webm](https://github.com/user-attachments/assets/c89909dc-9566-46cf-9c9b-42c6d5c60acd)


## Areas affected and ensured
Bill of Quantity item and bill of quantity doctype 

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?

  - Mozilla Firefox
  
