### PR TITLE
feat: fetch UOM and description on item selection in CNP doctype

### DIFF
--- a/stems/setup.py
+++ b/stems/setup.py
@@ -108,7 +108,7 @@ def get_stems_roles():
 	'''
 		Method to get Stems specific roles
 	'''
-	return ['Site Engineer','Drawing User','Estimation User']
+	return ['Site Engineer','Drawing User','Estimation User',' General Manager']
 
 def get_custom_fields():
 	'''

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -108,7 +108,7 @@ def get_stems_roles():
 	'''
 		Method to get Stems specific roles
 	'''
-	return ['Site Engineer','Drawing User','Estimation User',' General Manager']
+	return ['Site Engineer','Drawing User','Estimation User','General Manager']
 
 def get_custom_fields():
 	'''

--- a/stems/stems/doctype/customer_need_profile_item/customer_need_profile_item.json
+++ b/stems/stems/doctype/customer_need_profile_item/customer_need_profile_item.json
@@ -28,17 +28,21 @@
    "label": "Qty"
   },
   {
+   "fetch_from": "item.stock_uom",
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "UOM",
-   "options": "UOM"
+   "options": "UOM",
+   "read_only": 1
   },
   {
+   "fetch_from": "item.description",
    "fieldname": "description",
    "fieldtype": "Small Text",
    "in_list_view": 1,
-   "label": "Description"
+   "label": "Description",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -52,7 +56,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-09 15:59:09.485700",
+ "modified": "2026-01-13 15:34:03.998008",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Customer Need Profile Item",


### PR DESCRIPTION
- [x] TASK-2026-00066

- [x] TASK-2026-00077

## Feature description
Need to: 

- Fetch UOM and description on item selection in CNP doctype
- Add General Manager role 

## Solution description
- Fetched UOM and description on item selection in CNP doctype
- Added General Manager role 

## Output screenshots (optional)
<img width="1920" height="1080" alt="Screenshot from 2026-01-13 15-52-54" src="https://github.com/user-attachments/assets/18c55ea3-8134-4b14-8cae-e82a4a28e829" />

[Screencast from 13-01-26 03:53:12 PM IST.webm](https://github.com/user-attachments/assets/de2508c6-862e-4b43-a0cb-175450f44707)


## Areas affected and ensured
CNP doctype
Role 

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
