### PR TITLE
TASK-2026-00067:Display item name and description in Required Items table

### DIFF
--- a/stems/custom/custom_field/quotation.py
+++ b/stems/custom/custom_field/quotation.py
@@ -14,7 +14,7 @@ def get_quotation_custom_fields():
 			{
 				"fieldname": "required_items",
 				"fieldtype": "Table",
-				"options": "Quotation Item",
+				"options": "Quotation Required Item",
 				"label": "Required Items",
 				"insert_after": "items",
 			},

--- a/stems/stems/doctype/quotation_required_item/quotation_required_item.json
+++ b/stems/stems/doctype/quotation_required_item/quotation_required_item.json
@@ -1,0 +1,121 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-13 16:53:25.007010",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "column_break_fcqk",
+  "item_name",
+  "section_break_twem",
+  "description",
+  "section_break_jsfa",
+  "uom",
+  "rate",
+  "column_break_wcwq",
+  "qty",
+  "amount"
+ ],
+ "fields": [
+  {
+   "columns": 4,
+   "fieldname": "item_name",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Item Name",
+   "options": "Item",
+   "print_hide": 1,
+   "print_width": "150px",
+   "reqd": 1,
+   "width": "150px"
+  },
+  {
+   "fieldname": "column_break_fcqk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "item_name.stock_uom",
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM",
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_twem",
+   "fieldtype": "Section Break"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "item_name.description",
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "in_list_view": 1,
+   "label": "Description",
+   "print_width": "300px",
+   "width": "300px"
+  },
+  {
+   "fieldname": "section_break_jsfa",
+   "fieldtype": "Section Break"
+  },
+  {
+   "bold": 1,
+   "columns": 2,
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Quantity",
+   "reqd": 1
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "label": "Item Code",
+   "options": "Item",
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_wcwq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "bold": 1,
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "label": "Rate",
+   "options": "currency",
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "label": "Amount",
+   "options": "currency",
+   "print_width": "100px",
+   "read_only": 1,
+   "width": "100px"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-13 17:30:33.931146",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Quotation Required Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/quotation_required_item/quotation_required_item.py
+++ b/stems/stems/doctype/quotation_required_item/quotation_required_item.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class QuotationRequiredItem(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to: 

- Add new child doctype Quotation Required Item 
- The Required Items field in the Quotation DocType is  link to Quotation Required Item child doctype 
- Display item name and description in Required Items table and fetch uom and description from that selected item 

## Solution description
- Added new child doctype Quotation Required Item  with the feilds:-

   -   Item Name (Data / Link to item )
   -   Description (Text / Small Text)
   -   UOM
   -   Quantity
   -  Rate
   -  Amount

- The Required Items field in the Quotation DocType is  linked to Quotation Required Item child doctype 
- Displayed item name and description in Required Items table and  fetched uom and description from that selected item 


## Output screenshots (optional)
[Screencast from 14-01-26 10:18:01 AM IST.webm](https://github.com/user-attachments/assets/ed9b88f1-28cb-4b1c-ba06-181ad82e010a)

[Screencast from 14-01-26 10:18:31 AM IST.webm](https://github.com/user-attachments/assets/7513da5f-c49f-4abe-abc3-e176a262fe01)

## Areas affected and ensured
Quotation doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
