### PR TITLE
TASK-2026-00084:fetch item description when creating BOQ and Quotation

### DIFF
--- a/stems/stems/custom_scripts/opportunity/opportunity.py
+++ b/stems/stems/custom_scripts/opportunity/opportunity.py
@@ -261,6 +261,7 @@ def make_boq(source_name, target_doc=None):
 					item.item_name = row.item_name
 					item.qty = row.qty
 					item.uom = row.uom
+					item.description = row.description
 
 	doc = frappe.model.mapper.get_mapped_doc(
 		"Opportunity",

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -11,38 +11,39 @@ class BillofQuantity(Document):
 
 @frappe.whitelist()
 def make_quotation(source_name, target_doc=None):
-    """Create Quotation from BOQ with custom item rules"""
+	"""Create Quotation from BOQ with custom item rules"""
 
-    def postprocess(source, target):
-        target.quotation_to = "Lead"
-        target.party_name = source.lead
-        target.customer_name = frappe.db.get_value("Lead", source.lead, "lead_name")
-        target.customer_need_profile = source.customer_need_profile
-        target.items = []
-        target.required_items = []
+	def postprocess(source, target):
+		target.quotation_to = "Lead"
+		target.party_name = source.lead
+		target.customer_name = frappe.db.get_value("Lead", source.lead, "lead_name")
+		target.customer_need_profile = source.customer_need_profile
+		target.items = []
+		target.required_items = []
 
-        for row in source.items:
-            row_data = {
-                "item_code": row.item,
-                "item_name": row.item_name,
-                "qty": row.qty,
-                "uom": row.uom,
-                "customer_provided": row.customer_provided
-            }
-            if row.customer_provided:
-                target.append("required_items", row_data)
-            else:
-                target.append("items", row_data)
+		for row in source.items:
+			row_data = {
+				"item_code": row.item,
+				"item_name": row.item_name,
+				"qty": row.qty,
+				"uom": row.uom,
+				"customer_provided": row.customer_provided,
+				"description": row.description,
+			}
+			if row.customer_provided:
+				target.append("required_items", row_data)
+			else:
+				target.append("items", row_data)
 
-    doc = get_mapped_doc(
-        "Bill of Quantity",
-        source_name,
-        {
-            "Bill of Quantity": {
-                "doctype": "Quotation"
-            }
-        },
-        target_doc,
-        postprocess=postprocess
-    )
-    return doc
+	doc = get_mapped_doc(
+		"Bill of Quantity",
+		source_name,
+		{
+			"Bill of Quantity": {
+				"doctype": "Quotation"
+			}
+		},
+		target_doc,
+		postprocess=postprocess
+	)
+	return doc

--- a/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
+++ b/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
@@ -7,11 +7,11 @@
  "engine": "InnoDB",
  "field_order": [
   "item",
-  "item_name",
-  "qty",
+  "description",
   "uom",
+  "qty",
   "customer_provided",
-  "description"
+  "item_name"
  ],
  "fields": [
   {
@@ -26,7 +26,6 @@
    "fetch_from": "item.item_name",
    "fieldname": "item_name",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Item Name"
   },
   {
@@ -62,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-13 11:48:01.641289",
+ "modified": "2026-01-14 12:06:40.215779",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity Item",


### PR DESCRIPTION
## Feature description
Need to:

- Ensure item descriptions are consistently mapped from Enquiry → BOQ → Quotation
- Correct server-side mapping logic for child tables (Enquiry Items, BOQ Items, Quotation Items)
- Update Bill of Quantity grid view order to: item, description, UOM, quantity, customer provided

## Solution description

- Ensured item descriptions are consistently mapped from Enquiry → BOQ → Quotation
- Corrected server-side mapping logic for child tables (Enquiry Items, BOQ Items, Quotation Items)
- Updated Bill of Quantity grid view order to: item, description, UOM, quantity, customer provided
- 
## Output screenshots (optional)

[Screencast from 14-01-26 12:22:00 PM IST.webm](https://github.com/user-attachments/assets/1251e957-1997-479f-bfc3-c4eb70eaf800)


## Areas affected and ensured
Enquiry doctype and bill of quantity doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?
  - Chrome

