### PR TITLE
TASK-2026-00097: set warehouse from default project warehouse in STEMS Settings

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -46,7 +46,8 @@ app_license = "mit"
 doctype_js = {
 	"Lead": "stems/custom_scripts/lead/lead.js",
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js",
-	"Quotation":"stems/custom_scripts/quotation/quotation.js"
+	"Quotation":"stems/custom_scripts/quotation/quotation.js",
+	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js"
 }
 doctype_list_js = {
 	"Lead" : "stems/custom_scripts/lead/lead_list.js"

--- a/stems/stems/custom_scripts/delivery_note/delivery_note.js
+++ b/stems/stems/custom_scripts/delivery_note/delivery_note.js
@@ -1,0 +1,16 @@
+frappe.ui.form.on('Delivery Note', {
+	project (frm) {
+		if (frm.doc.project) {
+			frappe.call({
+				method: 'stems.stems.custom_scripts.delivery_note.delivery_note.get_default_project_warehouse',
+				callback: function (r) {
+					if (r.message) {
+						frm.set_value('set_warehouse', r.message);
+					}
+				}
+			});
+		} else {
+			frm.set_value('set_warehouse', '');
+		}
+	}
+});

--- a/stems/stems/custom_scripts/delivery_note/delivery_note.js
+++ b/stems/stems/custom_scripts/delivery_note/delivery_note.js
@@ -1,16 +1,22 @@
 frappe.ui.form.on('Delivery Note', {
 	project (frm) {
-		if (frm.doc.project) {
-			frappe.call({
-				method: 'stems.stems.custom_scripts.delivery_note.delivery_note.get_default_project_warehouse',
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value('set_warehouse', r.message);
-					}
-				}
-			});
-		} else {
-			frm.set_value('set_warehouse', '');
-		}
+		set_source_warehouse(frm);
 	}
 });
+
+/**
+ * Sets the Delivery Note's warehouse from STEMS Settings if a project is selected,
+ * or clears it if no project is linked.
+ */
+function set_source_warehouse(frm) {
+	if (frm.doc.project) {
+		frappe.db.get_single_value('STEMS Settings', 'default_project_warehouse')
+			.then(warehouse => {
+				if (warehouse) {
+					frm.set_value('set_warehouse', warehouse);
+				}
+			});
+	} else {
+		frm.set_value('set_warehouse', '');
+	}
+}

--- a/stems/stems/custom_scripts/delivery_note/delivery_note.py
+++ b/stems/stems/custom_scripts/delivery_note/delivery_note.py
@@ -1,9 +1,0 @@
-import frappe
-
-@frappe.whitelist()
-def get_default_project_warehouse():
-	"""Return the default project warehouse from STEMS Settings."""
-	return frappe.db.get_single_value(
-		"STEMS Settings",
-		"default_project_warehouse"
-	)

--- a/stems/stems/custom_scripts/delivery_note/delivery_note.py
+++ b/stems/stems/custom_scripts/delivery_note/delivery_note.py
@@ -1,0 +1,9 @@
+import frappe
+
+@frappe.whitelist()
+def get_default_project_warehouse():
+	"""Return the default project warehouse from STEMS Settings."""
+	return frappe.db.get_single_value(
+		"STEMS Settings",
+		"default_project_warehouse"
+	)

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -14,7 +14,9 @@
   "column_break_zbaj",
   "quotation_print_format",
   "enable_opportunity_activity_notification",
-  "event_email_template"
+  "event_email_template",
+  "section_break_vkyi",
+  "default_project_warehouse"
  ],
  "fields": [
   {
@@ -84,13 +86,25 @@
    "fieldname": "enable_quotation_follow_up",
    "fieldtype": "Check",
    "label": "Enable Quotation Follow Up Notification"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_vkyi",
+   "fieldtype": "Section Break",
+   "label": "Configurations"
+  },
+  {
+   "fieldname": "default_project_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Project Warehouse",
+   "options": "Warehouse"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-09 16:44:20.046322",
+ "modified": "2026-01-19 09:46:20.762213",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "STEMS Settings",


### PR DESCRIPTION
## Feature description
Add a Default Project Warehouse field in STEMS Settings.
When a Project is selected in Delivery Note, the set_warehouse field should be  populated from the STEMS Settings.
If the Project is cleared, the warehouse gets cleared
## Analysis and design (optional)
- This feature ensures project-based warehouse assignment for Delivery Notes.
- Uses a combination of:
  - Client Script: To dynamically set or clear set_warehouse when Project is selected/cleared.
  - Server-side whitelisted method: To fetch the default warehouse from STEMS Settings.

## Solution description
- Added Default Project Warehouse field in STEMS Settings under Configurations.
- Delivery Note client script sets set_warehouse when Project is selected, clears it if Project is cleared.
- Server-side whitelisted method get_default_project_warehouse fetches the warehouse value from STEMS Settings.
- Added Delivery Note client script in hooks.py.
## Output screenshots (optional)
**set default warehouse in STEMS Settings**
<img width="1353" height="355" alt="image" src="https://github.com/user-attachments/assets/6b2a1308-90f8-4982-8e75-d758ce9106fd" />
**Delivery Note form auto-fills set_warehouse when Project is selected.**
[Screencast from 01-19-2026 11:15:39 AM.webm](https://github.com/user-attachments/assets/6fe459f9-9ef2-4e73-8635-6b729518739f)

## Areas affected and ensured
- STEMS Settings: New field added.
- Delivery Note: Warehouse population logic.
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
