### PR TITLE
fix: Notification is not sent using the email template

### DIFF
--- a/stems/stems/custom_scripts/quotation/quotation.py
+++ b/stems/stems/custom_scripts/quotation/quotation.py
@@ -163,12 +163,15 @@ def follow_up_notification():
 		user = frappe.db.get_value("Employee", q.sales_person, "user_id")
 		if not user:
 			continue
-		message = settings.follow_up_notification_template.format(
-			quotation=q.name
-		)
+		template = frappe.get_doc("Email Template",settings.follow_up_notification_template)
+		context = {
+			"quotation": q.name,
+		}
+		subject = frappe.render_template(template.subject, context)
+		message = frappe.render_template(template.response, context)
 		frappe.get_doc({
 			"doctype": "Notification Log",
-			"subject": "Quotation Follow-up Required",
+			"subject": subject,
 			"email_content": message,
 			"for_user": user,
 			"document_type": "Quotation",


### PR DESCRIPTION
## Issue description

TASK-2026-00043
Notification is not sent using the email template for sales person to notify to submit the quotation



## Solution description
Updated the logic for sending Notification Logs to render the email template correctlly 

## Output screenshots (optional)

[Screencast from 19-01-26 11:36:57 AM IST.webm](https://github.com/user-attachments/assets/171d84b3-c815-4ed8-a4a7-57cbf98762e8)

## Areas affected and ensured
quotation doctype

## Is there any existing behavior change of other features due to this code change?
No.

## Was this feature tested on the browsers?

  - Mozilla Firefox
 
