### PR TITLE
feat: customize the item doctype

### DIFF
--- a/stems/custom/custom_field/item.py
+++ b/stems/custom/custom_field/item.py
@@ -10,5 +10,18 @@ def get_item_custom_fields():
 				"insert_after": "has_variants",
 				"label": "Is CNP Item",
 			},
+			{
+				"fieldname": "section_break_template",
+				"fieldtype": "Section Break",
+				"insert_after": "is_fixed_asset",
+				"label": "",
+			},
+			{
+				"fieldname": "task_template",
+				"fieldtype": "Table",
+				"options": "Task Templates",
+				"insert_after": "section_break_template",
+				"label": "Task Templates",
+			}
 		]
 	}

--- a/stems/custom/custom_field/item.py
+++ b/stems/custom/custom_field/item.py
@@ -22,6 +22,6 @@ def get_item_custom_fields():
 				"options": "Task Templates",
 				"insert_after": "section_break_template",
 				"label": "Task Templates",
-			}
+			},
 		]
 	}

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -47,7 +47,8 @@ doctype_js = {
 	"Lead": "stems/custom_scripts/lead/lead.js",
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js",
 	"Quotation":"stems/custom_scripts/quotation/quotation.js",
-	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js"
+	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js",
+    "Item":"stems/custom_scripts/item/item.js"
 }
 doctype_list_js = {
 	"Lead" : "stems/custom_scripts/lead/lead_list.js"

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -48,7 +48,7 @@ doctype_js = {
 	"Opportunity":"stems/custom_scripts/opportunity/opportunity.js",
 	"Quotation":"stems/custom_scripts/quotation/quotation.js",
 	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js",
-    "Item":"stems/custom_scripts/item/item.js"
+    "Item":"stems/custom_scripts/item/item.js",
 }
 doctype_list_js = {
 	"Lead" : "stems/custom_scripts/lead/lead_list.js"

--- a/stems/stems/custom_scripts/item/item.js
+++ b/stems/stems/custom_scripts/item/item.js
@@ -1,0 +1,20 @@
+frappe.ui.form.on('Item', {
+	refresh: function(frm) {
+		set_item_code_query(frm);
+	}
+});
+
+
+/**
+* Sets a filter on the Task Templates child table so that only Tasks
+* with the "Is Template" checkbox enabled are available for selection.
+*/
+function set_item_code_query(frm) {
+	frm.set_query("task_templates", "task_template", function () {
+		return {
+			filters: {
+				is_template: 1
+			}
+		};
+	});
+}

--- a/stems/stems/custom_scripts/item/item.js
+++ b/stems/stems/custom_scripts/item/item.js
@@ -18,3 +18,4 @@ function set_item_code_query(frm) {
 		};
 	});
 }
+

--- a/stems/stems/doctype/task_templates/task_templates.json
+++ b/stems/stems/doctype/task_templates/task_templates.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-19 14:55:12.767984",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "task_templates"
+ ],
+ "fields": [
+  {
+   "fieldname": "task_templates",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Task Template",
+   "options": "Task"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-19 15:00:40.886730",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Task Templates",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/task_templates/task_templates.py
+++ b/stems/stems/doctype/task_templates/task_templates.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TaskTemplates(Document):
+	pass


### PR DESCRIPTION
## Feature description
TASK-2026-00098
1. need to create child table  task templates 
2 need to link child table  task templates  in to the item doctype
3 On Tasks selected as Is Template checked  should be selectable


## Solution description
1. created task templates child table with field task template (link-task)
2. customized the item doctype
- added the table task templates and added section break 
3 added filter to get only is template checkbox checked task is selectable

## Output screenshots (optional)
[Screencast from 19-01-26 04:59:06 PM IST.webm](https://github.com/user-attachments/assets/c45f44d5-5141-4ee3-9824-87f833ec4e8d)
<img width="1903" height="959" alt="image" src="https://github.com/user-attachments/assets/7a6a533a-ac50-49bc-812e-2127740206d8" />

## Areas affected and ensured
item doctype

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
 
  - Mozilla Firefox
  