### PR TITLE
TASK-2026-00100: field for BOQ Reference in Quotation and Sales Order

### DIFF
--- a/stems/custom/custom_field/quotation.py
+++ b/stems/custom/custom_field/quotation.py
@@ -25,6 +25,12 @@ def get_quotation_custom_fields():
 				"label": "Sales Person",
 				"insert_after": "valid_till",
 			},
-			
+			{
+				"fieldname": "bill_of_quantity",
+				"fieldtype": "Link",
+				"options": "Bill of Quantity",
+				"label": "Bill of Quantity",
+				"insert_after": "customer_need_profile",
+			},
 		]
 	}

--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -1,0 +1,16 @@
+def get_sales_order_custom_fields():
+	"""
+	Custom fields that need to be added to the Sales Order DocType
+	"""
+	return {
+		"Sales Order": [
+			{
+				"fieldname": "bill_of_quantity",
+				"fieldtype": "Link",
+				"options": "Bill of Quantity",
+				"label": "Bill of Quantity",
+				"insert_after": "customer_need_profile",
+			},
+		]
+	}
+

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -5,6 +5,7 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from stems.custom.custom_field.item import get_item_custom_fields
 from stems.custom.custom_field.opportunity import get_opportunity_custom_fields
 from stems.custom.custom_field.quotation import get_quotation_custom_fields
+from stems.custom.custom_field.sales_order import get_sales_order_custom_fields
 
 
 def after_migrate():
@@ -117,6 +118,7 @@ def get_custom_fields():
 	custom_fields = get_item_custom_fields()
 	custom_fields.update(get_opportunity_custom_fields())
 	custom_fields.update(get_quotation_custom_fields())
+	custom_fields.update(get_sales_order_custom_fields())
 	return custom_fields
 
 def get_property_setters():

--- a/stems/stems/custom_scripts/quotation/quotation.py
+++ b/stems/stems/custom_scripts/quotation/quotation.py
@@ -46,6 +46,7 @@ def _make_sales_order_from_quotation(source_name, target_doc=None, ignore_permis
 			target.customer = customer.name
 			target.customer_name = customer.customer_name
 
+		target.bill_of_quantity = source.bill_of_quantity
 		if source.referral_sales_partner:
 			target.sales_partner = source.referral_sales_partner
 			target.commission_rate = frappe.get_value(

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -18,6 +18,7 @@ def make_quotation(source_name, target_doc=None):
 		target.party_name = source.lead
 		target.customer_name = frappe.db.get_value("Lead", source.lead, "lead_name")
 		target.customer_need_profile = source.customer_need_profile
+		target.bill_of_quantity = source.name
 		target.items = []
 		target.required_items = []
 


### PR DESCRIPTION
## Feature description
This feature adds a BOQ Reference field to Quotation and Sales Order to maintain traceability across documents.
When a Quotation is created from a BOQ, the BOQ reference is automatically populated.
When a Sales Order is created from that Quotation, the same BOQ reference is automatically carried forward.
## Analysis and design (optional)
To maintain end-to-end traceability without user intervention, a single BOQ reference is passed forward during document mapping:
- BOQ → Quotation
- Quotation → Sales Order
## Solution description
- Added a BOQ Reference link field in both Quotation and Sales Order.
- Updated the BOQ → Quotation mapping logic to automatically set the BOQ Reference when a Quotation is created from a BOQ.
- Updated the Quotation → Sales Order mapping logic to copy the BOQ Reference from the Quotation to the Sales Order.
## Output screenshots (optional)
<img width="1391" height="927" alt="image" src="https://github.com/user-attachments/assets/31e087f7-34eb-46b3-83db-7c4bf3098a6c" />
<img width="1391" height="927" alt="image" src="https://github.com/user-attachments/assets/7f0b82e7-55cc-4787-b9d2-d72b77954da2" />

## Areas affected and ensured
- Bill of Quantity → Quotation creation flow
- Quotation → Sales Order creation flow
- Quotation DocType (new BOQ Reference field)
- Sales Order DocType (new BOQ Reference field)

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
