### PR TITLE
TASK-2026-00101: link Bill of quantity with project

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -162,7 +162,10 @@ doc_events = {
 	},
 	"Quotation": {
 		"on_update": "stems.stems.custom_scripts.quotation.quotation.send_customer_approval_email"
-	}
+	},
+	"Project": {
+		"after_insert": "stems.stems.custom_scripts.project.project.link_project_to_boq",
+	},
 }
 
 # Scheduled Tasks

--- a/stems/stems/custom_scripts/project/project.py
+++ b/stems/stems/custom_scripts/project/project.py
@@ -1,0 +1,16 @@
+import frappe
+
+def link_project_to_boq(doc, method=None):
+	"""
+	When a Project is created from a Sales Order,
+	update the linked BOQ with the Project reference
+	"""
+	if not doc.sales_order:
+		return
+	
+	sales_order = frappe.get_doc("Sales Order", doc.sales_order)
+	if not sales_order.bill_of_quantity:
+		return
+	
+	frappe.db.set_value("Bill of Quantity",sales_order.bill_of_quantity,"project",doc.name,update_modified=False)
+

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
@@ -12,8 +12,10 @@
   "customer_name",
   "customer_need_profile",
   "billing_type",
+  "project",
   "section_break_fx68",
-  "items"
+  "items",
+  "amended_from"
  ],
  "fields": [
   {
@@ -61,12 +63,30 @@
    "fieldtype": "Select",
    "label": "Billing Type",
    "options": "\nService Only\nItems and Service"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Bill of Quantity",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2026-01-13 11:31:34.375990",
+ "modified": "2026-01-21 14:16:45.363366",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity",


### PR DESCRIPTION
## Feature description
- link a Bill of Quantity (BOQ) to a Project when the Project is created from a Sales Order. If the Sales Order has a BOQ reference, the system updates the BOQ with the newly created Project
- Made the Bill of Quantity doctype submittable

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Added a Project.after_insert hook in stems/hooks.py.
- Implemented link_project_to_boq method to:
  - Exit early if no Sales Order is linked.
  - Fetch the related Sales Order.
  - Check for a linked BOQ.
- Update the BOQ project field using frappe.db.set_value with update_modified=False to avoid unnecessary timestamp updates.
- Updated BOQ DocType to include a read-only Project link field for visibility.

## Output screenshots (optional)
<img width="1337" height="885" alt="image" src="https://github.com/user-attachments/assets/e528e321-6c39-4550-ae12-a57b6e5e4e6e" />

## Areas affected and ensured
- Project: Added after_insert hook logic.
- Sales Order: Read-only access for BOQ reference.
- Bill of Quantity:
  - Auto-population of Project field.
  - Schema updated to include read-only Project link.
- Hooks configuration: Updated to register Project event.
## Is there any existing behavior change of other features due to this code change?

Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
