### PR TITLE
feat: Fetch the stock balance and calculate the additional qty needed

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -2,21 +2,103 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Bill of Quantity', {
-    refresh: function(frm) {
-        if (!frm.is_new()) {
-            add_make_quotation_button(frm);
-        }
-    }
+	refresh: function(frm) {
+		if (!frm.is_new()) {
+			add_make_quotation_button(frm);
+		}
+	},
+	after_save: function(frm) {
+		show_additional_stock_message(frm);
+	},
+	onload : function(frm) {
+		frm.doc.items.forEach(function(row, index) {
+				stock_balance_fetch(frm, 'Bill of Quantity Item', row.name);
+		});
+	}
 });
 
 /*
- * Add button to create Quotation from Bill of Quantity
- */
+* Add button to create Quotation from Bill of Quantity
+*/
 function add_make_quotation_button(frm) {
-    frm.add_custom_button(__('Quotation'), function() {
-        frappe.model.open_mapped_doc({
-            method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.make_quotation",
-            frm: frm
-        });
-    }, __("Create"));
+	frm.add_custom_button(__('Quotation'), function() {
+		frappe.model.open_mapped_doc({
+			method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.make_quotation",
+			frm: frm
+		});
+	}, __("Create"));
 }
+
+frappe.ui.form.on('Bill of Quantity Item', {
+	item: function(frm, cdt, cdn) {
+		stock_balance_fetch(frm, cdt, cdn);
+	},
+	qty: function(frm, cdt, cdn) {   
+		calculate_additional_qty(frm, cdt, cdn);
+	},
+	stock_balance: function(frm, cdt, cdn) {
+		calculate_additional_qty(frm, cdt, cdn);
+	},
+	customer_provided: function(frm, cdt, cdn) {
+		calculate_additional_qty(frm, cdt, cdn);
+	},
+	item_add: function(frm, cdt, cdn) {
+		stock_balance_fetch(frm, cdt, cdn);
+	},
+});
+
+/**
+* Fetch stock balance for the selected item and update the child table row
+* If customer_provided is checked, skip stock balance calculation
+*/
+function stock_balance_fetch(frm, cdt, cdn) {
+	let row = locals[cdt][cdn];  
+	if (!row.item) return; 
+	frappe.call({
+		method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.get_item_stock_balance",
+		args: { item: row.item },
+		callback: function(r) {
+			row.stock_balance = r.message || 0;
+			calculate_additional_qty(frm, cdt, cdn);
+			frm.refresh_field("items"); 
+		}
+	});
+
+}
+
+/**
+* Calculate additional quantity needed based on stock balance and qty
+* Skip if customer_provided is checked
+*/
+function calculate_additional_qty(frm, cdt, cdn) {
+	let row = locals[cdt][cdn];
+	if  (!row.qty || row.customer_provided) {
+		row.additional_quantity_needed = 0;
+		frm.refresh_field("items");
+		return;
+	}
+	let additional_quantity_needed = row.qty - (row.stock_balance || 0);
+	row.additional_quantity_needed = additional_quantity_needed > 0 ? additional_quantity_needed : 0;
+	frm.refresh_field("items");
+}
+
+/**
+* Show a message listing items that need additional stock.
+*/
+function show_additional_stock_message(frm) {
+	let list = [];
+	(frm.doc.items || []).forEach(row => {
+		if (row.additional_quantity_needed > 0) {
+			list.push(`<b>${row.item}</b>-<b>${row.additional_quantity_needed}</b>`);
+		}
+	});
+	if (list.length) {
+		let message = `Item ${list.join(', ').replace(/, ([^,]*)$/, ', $1')} more units are needed`;
+
+		frappe.msgprint({
+			message: message,
+			indicator: 'orange'
+		});
+	}
+}
+

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -48,3 +48,18 @@ def make_quotation(source_name, target_doc=None):
 		postprocess=postprocess
 	)
 	return doc
+
+@frappe.whitelist()
+def get_item_stock_balance(item):
+	"""
+	Fetch the stock balance (actual quantity) of a given item in its default warehouse.
+	"""
+	if not item:
+		return 0
+	item_default = frappe.get_value("Item Default",{"parent":item},["company","default_warehouse"], as_dict = True)
+	if not item_default or not item_default.default_warehouse:
+		return 0
+	warehouse = item_default.default_warehouse
+	actual_qty = frappe.get_value("Bin",{"item_code":item , "warehouse":warehouse},"actual_qty") or 0
+	return actual_qty 
+

--- a/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
+++ b/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
@@ -11,7 +11,10 @@
   "uom",
   "qty",
   "customer_provided",
-  "item_name"
+  "item_name",
+  "column_break_toiq",
+  "stock_balance",
+  "additional_quantity_needed"
  ],
  "fields": [
   {
@@ -55,13 +58,31 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Description"
+  },
+  {
+   "fieldname": "stock_balance",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Stock Balance",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_toiq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "additional_quantity_needed",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Additional Quantity Needed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-14 12:06:40.215779",
+ "modified": "2026-01-21 16:50:03.899849",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity Item",


### PR DESCRIPTION
## Feature description
TASK-2026-00102
1. Need to add fields in the bill of quantity item child table 
2. need to  fetch the stock balance of item from warehouse 
3.  need to calculate additional quantity needed  
4.add msgprint after save doc to when the additional quantity needed have avalue

## Solution description

1.Added fields Stock Balance (Int, Read Only) and Additional Quantity Needed (Int, Read Only) to BOQ Item.
2.Fetches stock balance from the default warehouse when an item is selected. in bill of quantity doctype.

3.Calculates additional quantity needed when required quantity is higher than stock balance, and skips calculation if 4.Customer Provided is checked. bill of quantity doctype.

Added a frappe.msgprint alert after saving the document when additional stock is required. bill of quantity doctype.
## Output screenshots (optional)
<img width="1917" height="781" alt="image" src="https://github.com/user-attachments/assets/7a08a890-6928-4d8e-8956-b234ff6eaa13" />
[Screencast from 21-01-26 05:10:07 PM IST.webm](https://github.com/user-attachments/assets/9e7bd3bf-019b-4467-abb6-e13fa50240fc)
<img width="1917" height="781" alt="image" src="https://github.com/user-attachments/assets/c603d12f-e002-4bf6-823a-9a3ddeb6349a" />
[Screencast from 21-01-26 05:14:15 PM IST.webm](https://github.com/user-attachments/assets/dd719bcf-80a6-41df-bd77-4ba6823f7a1a)



## Areas affected and ensured
bill of quantity item and bill of quantity doctype

## Is there any existing behavior change of other features due to this code change?
 No.
## Was this feature tested on the browsers?

  - Mozilla Firefox

