### PR TITLE
fix(Sales Order): adjust insert position of BOQ custom field

### DIFF
--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -9,7 +9,7 @@ def get_sales_order_custom_fields():
 				"fieldtype": "Link",
 				"options": "Bill of Quantity",
 				"label": "Bill of Quantity",
-				"insert_after": "customer_need_profile",
+				"insert_after": "order_type",
 			},
 		]
 	}


### PR DESCRIPTION
## Feature description
Reposition the Bill of Quantity field in the Sales Order form because the Bill of Quantity field was not visible, as it was inserted after the Customer Need Profile field, which is not available
## Analysis and design (optional)
The Sales Order form currently places the Bill of Quantity field after Customer Need Profile, which is not available
## Solution description
- Updated the insert_after property of the Bill of Quantity custom field in sales_order.py.
- Changed the reference field from customer_need_profile to order_type.

## Output screenshots (optional)
Now the Bill of Quantity field is shown in sales order
<img width="1582" height="929" alt="image" src="https://github.com/user-attachments/assets/852202d8-9f58-474f-9c23-6f83af16f9fe" />

## Areas affected and ensured
- Sales Order DocType UI
## Is there any existing behavior change of other features due to this code change?

Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
