### PR TITLE
feat: Customize the task doctpe

### DIFF
--- a/stems/custom/custom_field/task.py
+++ b/stems/custom/custom_field/task.py
@@ -1,0 +1,22 @@
+def get_task_custom_fields():
+	'''
+		Method to get custom fields to be created for Task
+	'''
+	return {
+		"Task": [
+			{
+				"fieldname": "is_payment_required",
+				"fieldtype": "Check",
+				"insert_after": "parent_task",
+				"label": "Payment Required",
+			},
+			{
+				"fieldname": "payment_percentage",
+				"fieldtype": "Percent",
+				"insert_after": "is_payment_required",
+				"label": "Payment Percentage",
+				"depends_on": "eval:doc.is_payment_required == 1",
+				"mandatory_depends_on": "eval:doc.is_payment_required == 1",
+			},
+		]
+	}

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -49,6 +49,7 @@ doctype_js = {
 	"Quotation":"stems/custom_scripts/quotation/quotation.js",
 	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js",
     "Item":"stems/custom_scripts/item/item.js",
+    "Task":"stems/custom_scripts/task/task.js",
 }
 doctype_list_js = {
 	"Lead" : "stems/custom_scripts/lead/lead_list.js"

--- a/stems/setup.py
+++ b/stems/setup.py
@@ -6,6 +6,7 @@ from stems.custom.custom_field.item import get_item_custom_fields
 from stems.custom.custom_field.opportunity import get_opportunity_custom_fields
 from stems.custom.custom_field.quotation import get_quotation_custom_fields
 from stems.custom.custom_field.sales_order import get_sales_order_custom_fields
+from stems.custom.custom_field.task import get_task_custom_fields
 
 
 def after_migrate():
@@ -38,6 +39,7 @@ def delete_custom_fields_for_stems():
 	delete_custom_fields(get_opportunity_custom_fields())
 	delete_custom_fields(get_quotation_custom_fields())
 	delete_custom_fields(get_lead_custom_fields())
+	delete_custom_fields(get_task_custom_fields())
 
 def delete_custom_fields(custom_fields: dict):
 	'''
@@ -119,6 +121,7 @@ def get_custom_fields():
 	custom_fields.update(get_opportunity_custom_fields())
 	custom_fields.update(get_quotation_custom_fields())
 	custom_fields.update(get_sales_order_custom_fields())
+	custom_fields.update(get_task_custom_fields())
 	return custom_fields
 
 def get_property_setters():

--- a/stems/stems/custom_scripts/task/task.js
+++ b/stems/stems/custom_scripts/task/task.js
@@ -1,0 +1,15 @@
+
+frappe.ui.form.on('Task',{
+	is_payment_required: function(frm){
+		clear_check_box_exceed(frm);
+	}
+});
+
+/**
+* clears the "payment_percentage" field if "is_payment_required" is unchecked.
+*/
+function clear_check_box_exceed(frm){
+	if (frm.doc.is_payment_required == 0){
+		frm.set_value("payment_percentage",0);
+	}
+}


### PR DESCRIPTION
## Feature description
TASK-2026-00139
1. Need to add fields in task doctype
  - Payment Required , Payment Percentage 
2. if the checkbox uncheck the value of the percentage have value not clears  

## Solution description
1.  customized the fields in the task doctype
- payment required (check) 
-  payment percentage (percent)  
- added mandatory depends on and display depends on when the check box is checked 
2 . implement client side code when the checkbox uncheck the value of the percentage have value is cleared 

## Output screenshots (optional)

[Screencast from 22-01-26 02:48:05 PM IST.webm](https://github.com/user-attachments/assets/ff686428-4d53-4e17-9ca8-34186bb71a5a)

## Areas affected and ensured
task doctype

## Is there any existing behavior change of other features due to this code change?
 No

## Was this feature tested on the browsers?

  - Mozilla Firefox
 


