### PR TITLE
TASK-2026-00140:Add notification for payment required tasks

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -168,6 +168,9 @@ doc_events = {
 	"Project": {
 		"after_insert": "stems.stems.custom_scripts.project.project.link_project_to_boq",
 	},
+	"Task": {
+		"on_update": "stems.stems.custom_scripts.task.task.payment_requirement_notification",
+	},
 }
 
 # Scheduled Tasks

--- a/stems/stems/custom_scripts/task/task.js
+++ b/stems/stems/custom_scripts/task/task.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, efeone and contributors
+// For license information, please see license.txt
 
 frappe.ui.form.on('Task',{
 	is_payment_required: function(frm){

--- a/stems/stems/custom_scripts/task/task.py
+++ b/stems/stems/custom_scripts/task/task.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.utils import get_url_to_form
+
+def payment_requirement_notification(doc, method=None):
+	"""
+	Send payment requirement notification when a task is completed
+	and payment is required.
+	"""
+	if doc.status != "Completed":
+		return
+
+	previous_doc = doc.get_doc_before_save()
+	if previous_doc and previous_doc.status == "Completed":
+		return
+
+	if not doc.is_payment_required:
+		return
+
+	settings = frappe.get_single("STEMS Settings")
+	if not settings.enable_payment_task_notification:
+		frappe.log_error("Payment Task Notification Missing","Please enable payment task notifications in the settings.")
+		return
+
+	if not settings.payment_task_notification_role:
+		frappe.log_error("Payment Task Notification Missing","Payment task notification role is not configured.")
+		return
+
+	if not settings.payment_task_notification_template:
+		frappe.log_error("Payment Task Notification Missing","Payment task notification template is not configured.")
+		return
+
+	users = frappe.get_all(
+		"Has Role",
+		filters={"role": settings.payment_task_notification_role},
+		fields=["parent"]
+	)
+
+	if not users:
+		return
+
+	template = frappe.get_doc(
+		"Email Template",
+		settings.payment_task_notification_template
+	)
+
+	for u in users:
+		user = u.parent
+
+		if not frappe.db.get_value("User", user, "enabled"):
+			continue
+
+		context = {
+			"task_subject": doc.subject,
+			"payment_percentage": doc.payment_percentage or 0,
+			"project": doc.project,
+		}
+
+		subject = frappe.render_template(template.subject, context)
+		message = frappe.render_template(template.response, context)
+
+		frappe.get_doc({
+			"doctype": "Notification Log",
+			"subject": subject,
+			"email_content": message,
+			"for_user": user,
+			"document_type": "Task",
+			"document_name": doc.name
+		}).insert(ignore_permissions=True)

--- a/stems/stems/doctype/stems_settings/stems_settings.js
+++ b/stems/stems/doctype/stems_settings/stems_settings.js
@@ -4,6 +4,9 @@
 frappe.ui.form.on('STEMS Settings', {
 	refresh: function(frm) {
 		set_quotation_print_format(frm);
+	},
+	enable_payment_task_notification: function (frm) {
+		handle_payment_task_notification_toggle(frm);
 	}
 });
 
@@ -19,3 +22,17 @@ function set_quotation_print_format(frm) {
 		}
 	});	
 }
+
+/*
+ * Function to handle clearing fields when Payment Task Notification is disabled
+ */
+function handle_payment_task_notification_toggle(frm) {
+	if (!frm.doc.enable_payment_task_notification) {
+		frm.set_value('payment_task_notification_template', '');
+		frm.set_value('payment_task_notification_role', '');
+
+		frm.refresh_field('payment_task_notification_template');
+		frm.refresh_field('payment_task_notification_role');
+	}
+}
+

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -15,6 +15,9 @@
   "quotation_print_format",
   "enable_opportunity_activity_notification",
   "event_email_template",
+  "enable_payment_task_notification",
+  "payment_task_notification_template",
+  "payment_task_notification_role",
   "section_break_vkyi",
   "default_project_warehouse"
  ],
@@ -98,13 +101,35 @@
    "fieldtype": "Link",
    "label": "Default Project Warehouse",
    "options": "Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_payment_task_notification",
+   "fieldtype": "Check",
+   "label": "Enable Payment Task Notification"
+  },
+  {
+   "depends_on": "eval:doc.enable_payment_task_notification\n",
+   "description": "Email & notification template used when a payment-required task is completed.",
+   "fieldname": "payment_task_notification_template",
+   "fieldtype": "Link",
+   "label": "Payment Task Notification Template",
+   "options": "Email Template"
+  },
+  {
+   "depends_on": "eval:doc.enable_payment_task_notification\n",
+   "description": "Users with this role will receive email and system notifications.",
+   "fieldname": "payment_task_notification_role",
+   "fieldtype": "Link",
+   "label": "Payment Task Notification Role",
+   "options": "Role"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-19 09:46:20.762213",
+ "modified": "2026-01-22 17:12:14.255184",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "STEMS Settings",


### PR DESCRIPTION
## Feature description
Need to: 
The system now supports notification settings for payment-required tasks configure:

- Enable/Disable Payment Task Notifications (enable_payment_task_notification)
- Role to Notify (payment_task_notification_role)
- Notification Template (payment_task_notification_template)
- This allows the system to send notifications to the appropriate users whenever a payment-related task requires attention.

## Solution description

- Added new settings fields for enabling notifications, selecting the role, and specifying the template.
- Implemented validation checks to ensure all required settings are configured.
- Added error logs using frappe.log_error if any setting is missing, providing a clear title and subject for admins to identify missing configurations.
- Ensures that notifications are sent only when all required settings are properly configured.

## Output screenshots (optional)
[Screencast from 23-01-26 11:59:36 AM IST.webm](https://github.com/user-attachments/assets/c2cc537a-d2c5-45bb-a707-a8d83651da52)

[Screencast from 23-01-26 12:02:03 PM IST.webm](https://github.com/user-attachments/assets/54077d0e-3d6c-4300-9dde-8dce8733e6fc)


## Areas affected and ensured
Task doctype and stems settings doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

