### PR TITLE
TASK-2026-00104:Add Stock Transfer button in Bill of Quantity

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -7,6 +7,9 @@ frappe.ui.form.on('Bill of Quantity', {
 			add_make_quotation_button(frm);
 			add_create_rfq_button(frm);
 		}
+        if (frm.doc.project && frm.doc.docstatus === 1) {
+			add_transfer_stock_button(frm);
+		}
 	},
 	after_save: function(frm) {
 		show_additional_stock_message(frm);
@@ -125,3 +128,95 @@ function add_create_rfq_button(frm) {
     }
 }
 
+/*
+* Add button to transfer stock to Project Warehouse
+*/
+function add_transfer_stock_button(frm) {
+	frm.add_custom_button(__('Transfer Stock to Project'), function() {
+		transfer_stock_to_project(frm);
+	});
+}
+
+/**
+ * Transfer stock to Project Warehouse
+ */
+function transfer_stock_to_project(frm) {
+    let items_to_transfer = (frm.doc.items || []).filter(row => {
+        let required_qty = (row.qty || 0) - (row.transferred_quantity || 0);
+        return !row.customer_provided && required_qty > 0;
+    });
+
+    if (!items_to_transfer.length) {
+        frappe.msgprint(__('All items are already transferred.'));
+        return;
+    }
+
+    let fields = items_to_transfer.map(row => {
+        let required_qty = (row.qty || 0) - (row.transferred_quantity || 0);
+        let stock_available = row.stock_balance || 0;
+
+        let default_value = (stock_available < required_qty) ? stock_available : required_qty;
+
+        return {
+            fieldname: row.item,
+            label: `${row.item_name}`,
+            fieldtype: 'Float',
+            default: default_value,
+            description: `Stock Balance: ${stock_available},Required Qty: ${required_qty}`,
+            reqd: 1,
+            precision: 3
+        };
+    });
+
+    let dialog = new frappe.ui.Dialog({
+        title: __('Transfer Stock to Project Warehouse'),
+        fields: fields,
+        primary_action_label: __('Transfer'),
+        primary_action(values) {
+            let transfer_items = [];
+
+            for (let item_code in values) {
+                let row = items_to_transfer.find(i => i.item === item_code);
+                let required_qty = (row.qty || 0) - (row.transferred_quantity || 0);
+                let stock_available = row.stock_balance || 0;
+
+                if (values[item_code] > required_qty) {
+                    frappe.msgprint(
+                        __('Cannot transfer more than required quantity for {0}', [row.item_name])
+                    );
+                    return;
+                }
+
+                if (values[item_code] > stock_available) {
+                    frappe.msgprint(
+                        __('Cannot transfer more than stock available for {0}', [row.item_name])
+                    );
+                    return;
+                }
+
+                if (values[item_code] > 0) {
+                    transfer_items.push({
+                        item_code: item_code,
+                        qty: values[item_code]
+                    });
+                }
+            }
+
+            frappe.call({
+                method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.transfer_stock_to_project",
+                args: {
+                    boq_name: frm.doc.name,
+                    items: transfer_items
+                },
+                callback: function(r) {
+                    if (!r.exc) {
+                        frm.reload_doc();
+                        dialog.hide();
+                    }
+                }
+            });
+        }
+    });
+
+    dialog.show();
+}

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.json
@@ -86,7 +86,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-21 14:16:45.363366",
+ "modified": "2026-01-23 15:23:23.874109",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity",

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -5,6 +5,10 @@ import frappe
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import today
+from frappe import _
+from frappe.utils.data import flt
+from frappe.utils import get_url_to_form
+
 
 
 class BillofQuantity(Document):
@@ -110,3 +114,87 @@ def create_rfq_from_boq(source_name):
 
 	rfq.insert(ignore_permissions=True, ignore_mandatory=True)
 	return rfq.name
+
+@frappe.whitelist()
+def transfer_stock_to_project(boq_name, items):
+    """
+    	Transfer stock from Item default warehouse to Project warehouse
+    	based on BOQ items. Uses required_qty = qty - transferred_quantity.
+    """
+    boq_doc = frappe.get_doc("Bill of Quantity", boq_name)
+
+    if not boq_doc.project:
+        frappe.throw(_("Project is not linked to this BOQ"))
+
+    items = frappe.parse_json(items)
+
+    company = frappe.db.get_value("Project", boq_doc.project, "company")
+    if not company:
+        frappe.throw(_("Company not found in linked Project"))
+
+    project_warehouse = frappe.db.get_single_value("STEMS Settings", "default_project_warehouse")
+    if not project_warehouse:
+        frappe.throw(_("Default Project Warehouse not set in STEMS Settings"))
+
+    stock_entry = frappe.get_doc({
+        "doctype": "Stock Entry",
+        "stock_entry_type": "Material Transfer",
+        "company": company,
+        "items": []
+    })
+
+    transferred_any_item = False
+
+    for transfer_row in items:
+        item_code = transfer_row.get("item_code")
+        transfer_qty = flt(transfer_row.get("qty"))
+
+        if not item_code or transfer_qty <= 0:
+            continue
+
+        boq_item = next((row for row in boq_doc.items if row.item == item_code), None)
+        if not boq_item:
+            frappe.throw(_("Item {0} not found in BOQ").format(item_code))
+
+        required_qty = flt(boq_item.qty) - flt(boq_item.transferred_quantity or 0)
+        if required_qty <= 0:
+            continue
+
+        if transfer_qty > required_qty:
+            frappe.throw(
+                _("Cannot transfer more than required quantity for item {0}. Required: {1}")
+                .format(item_code, required_qty)
+            )
+
+        from_warehouse = frappe.db.get_value(
+            "Item Default",
+            {"parent": item_code, "company": company},
+            "default_warehouse"
+        )
+        if not from_warehouse:
+            frappe.throw(
+                _("Default Warehouse not set for Item {0} in Company {1}")
+                .format(item_code, company)
+            )
+
+        stock_entry.append("items", {
+            "item_code": item_code,
+            "qty": transfer_qty,
+            "s_warehouse": from_warehouse,
+            "t_warehouse": project_warehouse
+        })
+
+        boq_item.transferred_quantity = flt(boq_item.transferred_quantity or 0) + transfer_qty
+        transferred_any_item = True
+
+    if not transferred_any_item:
+        frappe.msgprint(_("All items are already transferred"))
+        return
+
+    stock_entry.insert()
+    stock_entry.submit()
+    boq_doc.save()
+
+    frappe.msgprint(
+    _('Stock successfully transferred to Project Warehouse.<br>'
+      'Stock Entry: <a href="{0}">{1}</a>').format(get_url_to_form(stock_entry.doctype, stock_entry.name),stock_entry.name),alert=True,indicator='green')

--- a/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
+++ b/stems/stems/doctype/bill_of_quantity_item/bill_of_quantity_item.json
@@ -14,7 +14,8 @@
   "item_name",
   "column_break_toiq",
   "stock_balance",
-  "additional_quantity_needed"
+  "additional_quantity_needed",
+  "transferred_quantity"
  ],
  "fields": [
   {
@@ -76,13 +77,20 @@
    "in_list_view": 1,
    "label": "Additional Quantity Needed",
    "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "transferred_quantity",
+   "fieldtype": "Float",
+   "label": "Transferred Quantity",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-21 16:50:03.899849",
+ "modified": "2026-01-23 15:23:43.088099",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "Bill of Quantity Item",


### PR DESCRIPTION
## Feature description
Need to:
- Add "Transfer Stock to Project" button in Bill of Quantity form
- Open dialog showing required quantity vs available stock
- Auto-suggest transferable quantity based on stock balance
- Prevent over-transfer beyond required or available quantity
- Create and submit Stock Entry (Material Transfer)
- Update transferred quantity in BOQ items
- Show success message with clickable Stock Entry link

## Solution description

- Added a “Transfer Stock to Project” button in the BOQ form.
- On clicking the button, a dialog is displayed showing only transferable items:
     -  Excludes customer-provided items
- The dialog displays:
     - Required Quantity (BOQ Qty − Transferred Qty)
     - Available Stock Balance
- Implemented validations to prevent:

      - Transferring more than the required quantity
     - Transferring more than available stock

- A Stock Entry (Material Transfer) is created and submitted

     - Stock is transferred from the item’s default warehouse to the project warehouse
     - Transferred quantity is updated in the BOQ item

- Displays a success message with a clickable link to the created Stock Entry for easy navigation and verification.

## Output screenshots (optional)
[Screencast from 23-01-26 04:20:47 PM IST.webm](https://github.com/user-attachments/assets/0d21e2e8-c131-4f7a-95bc-68c7c9419265)

[Screencast from 23-01-26 04:19:29 PM IST.webm](https://github.com/user-attachments/assets/611e2e9b-830a-4ed1-8025-0cf33e5cae75)


## Areas affected and ensured
Bill of quantity doctype

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
 
