### PR TITLE
TASK-2026-00141:Add task wise payment summary table in Sales Order

### DIFF
--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -36,6 +36,21 @@ def get_sales_order_custom_fields():
 				"label": "Project Name",
 				"insert_after": "column_break_project",
 			},
+			{
+				"fieldname": "task_wise_payment_summary",
+				"fieldtype": "Section Break",
+				"label": "Task Wise Payment Summary",
+				"insert_after": "project",
+				"collapsible": 1,
+			},
+			{
+				"fieldname": "task_wise_pay",
+				"fieldtype": "Table",
+				"label": "Task Wise Pay",
+				"options": "Task Wise Pay",
+				"allow_on_submit": 1,
+				"insert_after": "task_wise_payment_summary",
+			},
 		]
 	}
 

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -170,7 +170,10 @@ doc_events = {
 		"after_insert": "stems.stems.custom_scripts.project.project.link_project_to_boq",
 	},
 	"Task": {
-		"on_update": "stems.stems.custom_scripts.task.task.payment_requirement_notification",
+		"on_update": [
+			"stems.stems.custom_scripts.task.task.payment_requirement_notification",
+			"stems.stems.custom_scripts.task.task.sync_task_payment_to_sales_order"
+		],
 	},
 	"Stock Entry": {
 		"validate": "stems.stems.custom_scripts.stock_entry.stock_entry.validate_stock_entry_qty",

--- a/stems/stems/custom_scripts/sales_order/sales_order.js
+++ b/stems/stems/custom_scripts/sales_order/sales_order.js
@@ -4,6 +4,8 @@ frappe.ui.form.on('Sales Order', {
 	},
 	refresh: function(frm) {
 		calculate_item_delivery_dates(frm);
+		allow_task_table_edit_after_submit(frm);
+
 	}
 });
 
@@ -16,6 +18,15 @@ frappe.ui.form.on('Sales Order Item', {
 	},
 	items_remove: function(frm) {
 		calculate_item_delivery_dates(frm);
+	}
+});
+
+frappe.ui.form.on("Task Wise Pay", {
+	item(frm, cdt, cdn) {
+		fetch_item_description(cdt, cdn);
+	},
+	percentage(frm, cdt, cdn) {
+		recalculate_task_amount(frm, cdt, cdn);
 	}
 });
 
@@ -67,4 +78,42 @@ function calculate_item_delivery_dates(frm) {
 			frm.set_value("delivery_date", parent_latest_date);
 		}
 	});
+}
+
+/**
+* Allow editing Task Wise Pay child table after submit
+*/
+function allow_task_table_edit_after_submit(frm) {
+	if (frm.doc.docstatus === 1) {
+		frm.set_df_property("task_wise_pay", "cannot_delete_rows", false);
+	}
+}
+
+/**
+ * Fetch item description from Item master
+ */
+function fetch_item_description(cdt, cdn) {
+	let row = locals[cdt][cdn];
+	if (!row.item) return;
+
+	frappe.model.with_doc("Item", row.item, function () {
+		let item_doc = frappe.get_doc("Item", row.item);
+		frappe.model.set_value(
+			cdt,
+			cdn,
+			"item_description",
+			item_doc.item_name || item_doc.description || ""
+		);
+	});
+}
+
+/**
+ * Recalculate amount based on percentage
+ */
+function recalculate_task_amount(frm, cdt, cdn) {
+	let row = locals[cdt][cdn];
+	let total = frm.doc.grand_total || 0;
+	let percentage = row.percentage || 0;
+
+	frappe.model.set_value(cdt,cdn,"amount",(total * percentage) / 100);
 }

--- a/stems/stems/custom_scripts/task/task.py
+++ b/stems/stems/custom_scripts/task/task.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025, efeone and contributors
 # For license information, please see license.txt
 
+from annotated_types import doc
+from pydoc import doc
 import frappe
 from frappe.utils import get_url_to_form
 
@@ -69,3 +71,60 @@ def payment_requirement_notification(doc, method=None):
 			"document_type": "Task",
 			"document_name": doc.name
 		}).insert(ignore_permissions=True)
+
+def sync_task_payment_to_sales_order(doc, method):
+	"""
+	Sync task payment details to linked Sales Orders
+	when a task is completed and payment is required
+	"""
+
+	if doc.status != "Completed":
+		return
+
+	if not doc.is_payment_required:
+		return
+
+	if not doc.project:
+		return
+
+	sales_orders = frappe.get_all(
+		"Sales Order",
+		filters={
+			"project": doc.project,
+			"docstatus": 1
+		},
+		pluck="name"
+	)
+
+	if not sales_orders:
+		return
+
+	for so_name in sales_orders:
+		add_task_to_sales_order(so_name, doc)
+
+
+def add_task_to_sales_order(so_name, task_doc):
+	"""
+	Add task-wise payment entry to Sales Order
+	if it does not already exist
+	"""
+
+	so = frappe.get_doc("Sales Order", so_name)
+
+	existing_tasks = [row.task for row in (so.task_wise_pay or [])]
+	if task_doc.name in existing_tasks:
+		return
+
+	total = so.grand_total or 0
+	percentage = task_doc.payment_percentage or 0
+
+	so.append("task_wise_pay", {
+		"task": task_doc.name,
+		"percentage": percentage,
+		"amount": (total * percentage) / 100,
+		"add_to_print": 0
+	})
+
+	so.flags.ignore_permissions = True
+	so.flags.ignore_validate_update_after_submit = True
+	so.save()

--- a/stems/stems/doctype/task_wise_pay/task_wise_pay.json
+++ b/stems/stems/doctype/task_wise_pay/task_wise_pay.json
@@ -1,0 +1,80 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-01-28 10:31:59.421833",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "task",
+  "percentage",
+  "amount",
+  "item",
+  "item_description",
+  "add_to_print"
+ ],
+ "fields": [
+  {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Task",
+   "options": "Task",
+   "read_only": 1
+  },
+  {
+   "fieldname": "percentage",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Percentage",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item",
+   "options": "Item"
+  },
+  {
+   "allow_on_submit": 1,
+   "fetch_from": "item.item_name",
+   "fieldname": "item_description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Item Description",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "add_to_print",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Add to Print"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-01-28 17:18:45.407898",
+ "modified_by": "Administrator",
+ "module": "STEMS",
+ "name": "Task Wise Pay",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/stems/stems/doctype/task_wise_pay/task_wise_pay.py
+++ b/stems/stems/doctype/task_wise_pay/task_wise_pay.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class TaskWisePay(Document):
+	pass


### PR DESCRIPTION
## Feature description
Need to: 

- Add Task Wise Payment Summary table in Sales Order.
- The table displays completed Project Tasks where Payment Required is enabled.
- Helps track task based payment breakup directly inside the Sales Order.

## Solution description

- Added a custom child table in Sales Order with the following fields:
    - Task (Link → Task)
    - Percentage (Percent)
    - Amount (Currency)
    - Item (Link → Item)
    - Item Description (auto-filled from Item)
    - Add to Print (Check)

- Implemented logic to:

- Fetch only completed Tasks from the same Project linked to the Sales Order.

- Auto-populate:

     Task
     Payment Percentage from Task
     Amount as a percentage of Sales Order total
     Keep Item and Add to Print fields editable after submission.
     Item Description is auto-filled when Item is selected.


## Output screenshots (optional)

[Screencast from 28-01-26 05:26:59 PM IST.webm](https://github.com/user-attachments/assets/0efca029-5d94-4546-b5f0-09d11234fd9b)

[Screencast from 28-01-26 05:28:18 PM IST.webm](https://github.com/user-attachments/assets/a7ecc7e0-34a8-48d5-aa0e-2584d3a6bd1f)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
