### PR TITLE
TASK-2026-00169:Stock Quantity Validation in BOQ to Stock Entry

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('Bill of Quantity', {
 	},
 	onload : function(frm) {
 		frm.doc.items.forEach(function(row, index) {
-				stock_balance_fetch(frm, 'Bill of Quantity Item', row.name);
+			stock_balance_fetch(frm, 'Bill of Quantity Item', row.name);
 		});
 	}
 });
@@ -52,38 +52,63 @@ frappe.ui.form.on('Bill of Quantity Item', {
 });
 
 /**
-* Fetch stock balance for the selected item and update the child table row
-* If customer_provided is checked, skip stock balance calculation
+* Check if item is a stock item before fetching stock balance
+*/
+function check_and_fetch_stock_balance(frm, cdt, cdn) {
+	let row = locals[cdt][cdn];
+	if (!row.item) return;
+
+	frappe.db.get_value('Item', row.item, 'is_stock_item', (r) => {
+		if (r && r.is_stock_item) {
+			stock_balance_fetch(frm, cdt, cdn);
+		} else {
+			row.stock_balance = 0;
+			row.additional_quantity_needed = 0;
+			row.transferred_quantity = 0;
+			frm.refresh_field("items");
+		}
+	});
+}
+
+/**
+* Fetch stock balance for stock items
 */
 function stock_balance_fetch(frm, cdt, cdn) {
-	let row = locals[cdt][cdn];  
-	if (!row.item) return; 
+	let row = locals[cdt][cdn];
+	if (!row.item) return;
+
 	frappe.call({
 		method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.get_item_stock_balance",
 		args: { item: row.item },
 		callback: function(r) {
 			row.stock_balance = r.message || 0;
 			calculate_additional_qty(frm, cdt, cdn);
-			frm.refresh_field("items"); 
+			frm.refresh_field("items");
 		}
 	});
-
 }
 
 /**
-* Calculate additional quantity needed based on stock balance and qty
-* Skip if customer_provided is checked
+* Calculate additional quantity needed
 */
 function calculate_additional_qty(frm, cdt, cdn) {
 	let row = locals[cdt][cdn];
-	if  (!row.qty || row.customer_provided) {
+
+	if (!row.item) {
 		row.additional_quantity_needed = 0;
 		frm.refresh_field("items");
 		return;
 	}
-	let additional_quantity_needed = row.qty - (row.stock_balance || 0);
-	row.additional_quantity_needed = additional_quantity_needed > 0 ? additional_quantity_needed : 0;
-	frm.refresh_field("items");
+
+	frappe.db.get_value('Item', row.item, 'is_stock_item', (r) => {
+		if (!r || !r.is_stock_item || !row.qty || row.customer_provided) {
+			row.additional_quantity_needed = 0;
+		} else {
+			let shortage = row.qty - (row.stock_balance || 0);
+			row.additional_quantity_needed = shortage > 0 ? shortage : 0;
+		}
+		frm.refresh_field("items");
+	});
 }
 
 /**
@@ -107,63 +132,100 @@ function show_additional_stock_message(frm) {
 }
 
 /*
- * Add button to create RFQ from Bill of Quantity
- */
+* Add button to create RFQ from Bill of Quantity
+* Only show if there are stock items with shortage
+*/
 function add_create_rfq_button(frm) {
-    // Check if any item has additional quantity needed
-    let has_shortage = frm.doc.items.some(row => row.additional_quantity_needed > 0);
+	let has_shortage = false;
 
-    if (has_shortage) {
-        frm.add_custom_button("Request for Quotation", function() {
-            frappe.call({
-                method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.create_rfq_from_boq",
-                args: { source_name: frm.doc.name },
-                callback: function(r) {
-                    if (r.message) {
-                        frappe.set_route("Form", "Request for Quotation", r.message);
-                    }
-                }
-            });
-        }, "Create");
-    }
+	(frm.doc.items || []).forEach(row => {
+		if (row.additional_quantity_needed > 0) {
+			has_shortage = true;
+		}
+	});
+
+	if (has_shortage) {
+		frm.add_custom_button("Request for Quotation", function() {
+			frappe.call({
+				method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.create_rfq_from_boq",
+				args: { source_name: frm.doc.name },
+				callback: function(r) {
+					if (r.message) {
+						frappe.set_route("Form", "Request for Quotation", r.message);
+					}
+				}
+			});
+		}, "Create");
+	}
 }
 
 /*
- * Add button to transfer stock to Project Warehouse
- */
+* Add button to transfer stock to Project Warehouse
+*/
 function add_transfer_stock_button(frm) {
-	frm.add_custom_button(__('Transfer Stock to Project'), function () {
-		transfer_stock_to_project(frm);
+	let has_items_to_transfer = false;
+
+	(frm.doc.items || []).forEach(row => {
+		let required_qty = (row.qty || 0) - (row.transferred_quantity || 0);
+		if (!row.customer_provided && required_qty > 0) {
+			has_items_to_transfer = true;
+		}
 	});
+
+	if (has_items_to_transfer) {
+		frm.add_custom_button(__('Transfer Stock to Project'), function() {
+			transfer_stock_to_project(frm);
+		});
+	}
 }
 
 /**
- * Create Draft Stock Entry and redirect user
- */
+* Create Draft Stock Entry and redirect user
+* Only transfers stock items
+*/
 function transfer_stock_to_project(frm) {
-	// Check if there is anything left to transfer
-	let has_items_to_transfer = (frm.doc.items || []).some(row => {
+	let items_to_check = [];
+
+	(frm.doc.items || []).forEach(row => {
 		let required_qty = (row.qty || 0) - (row.transferred_quantity || 0);
-		return !row.customer_provided && required_qty > 0;
+		if (!row.customer_provided && required_qty > 0 && row.item) {
+			items_to_check.push(row.item);
+		}
 	});
 
-	if (!has_items_to_transfer) {
+	if (items_to_check.length === 0) {
 		frappe.msgprint(__('All items are already transferred or customer-provided.'));
 		return;
 	}
 
-	frappe.call({
-		method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.transfer_stock_to_project",
-		args: {
-			boq_name: frm.doc.name
-		},
-		freeze: true,
-		freeze_message: __('Creating Stock Entry...'),
-		callback(r) {
-			if (r.message) {
-				// Redirect to Draft Stock Entry
-				frappe.set_route("Form", "Stock Entry", r.message);
+	let stock_items_found = 0;
+	let checks_completed = 0;
+
+	items_to_check.forEach(item => {
+		frappe.db.get_value('Item', item, 'is_stock_item', (r) => {
+			checks_completed++;
+			if (r && r.is_stock_item) {
+				stock_items_found++;
 			}
-		}
+
+			if (checks_completed === items_to_check.length) {
+				if (stock_items_found === 0) {
+					frappe.msgprint(__('No stock items available to transfer.'));
+					return;
+				}
+
+				frappe.call({
+					method: "stems.stems.doctype.bill_of_quantity.bill_of_quantity.transfer_stock_to_project",
+					args: { boq_name: frm.doc.name },
+					freeze: true,
+					freeze_message: __('Creating Stock Entry...'),
+					callback(r) {
+						if (r.message) {
+							frappe.set_route("Form", "Stock Entry", r.message);
+						}
+					}
+				});
+			}
+		});
 	});
 }

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -9,8 +9,6 @@ from frappe import _
 from frappe.utils.data import flt
 from frappe.utils import get_url_to_form
 
-
-
 class BillofQuantity(Document):
 	pass
 
@@ -58,9 +56,15 @@ def make_quotation(source_name, target_doc=None):
 def get_item_stock_balance(item):
 	"""
 	Fetch the stock balance (actual quantity) of a given item in its default warehouse.
+	Only for stock items.
 	"""
 	if not item:
 		return 0
+
+	is_stock_item = frappe.db.get_value("Item", item, "is_stock_item")
+	if not is_stock_item:
+		return 0
+
 	item_default = frappe.get_value("Item Default",{"parent":item},["company","default_warehouse"], as_dict = True)
 	if not item_default or not item_default.default_warehouse:
 		return 0
@@ -72,6 +76,7 @@ def get_item_stock_balance(item):
 def create_rfq_from_boq(source_name):
 	"""
 		Create Request for Quotation from Bill of Quantity considering stock levels
+		Only for stock items
 	"""
 	boq = frappe.get_doc("Bill of Quantity", source_name)
 
@@ -85,6 +90,10 @@ def create_rfq_from_boq(source_name):
 			continue
 
 		if row.customer_provided:
+			continue
+
+		is_stock_item = frappe.db.get_value("Item", row.item, "is_stock_item")
+		if not is_stock_item:
 			continue
 
 		stock_uom = frappe.get_value("Item", row.item, "stock_uom")
@@ -120,6 +129,7 @@ def transfer_stock_to_project(boq_name):
 	"""
 	Create a Draft Stock Entry from BOQ
 	Qty fetched will never exceed available stock
+	Only for stock items
 	"""
 
 	boq = frappe.get_doc("Bill of Quantity", boq_name)
@@ -147,6 +157,10 @@ def transfer_stock_to_project(boq_name):
 
 	for row in boq.items:
 		if row.customer_provided:
+			continue
+
+		is_stock_item = frappe.db.get_value("Item", row.item, "is_stock_item")
+		if not is_stock_item:
 			continue
 
 		required_qty = flt(row.qty) - flt(row.transferred_quantity or 0)
@@ -183,7 +197,8 @@ def transfer_stock_to_project(boq_name):
 		})
 
 	if not stock_entry.items:
-		frappe.throw(_("No stock available to transfer"))
+		frappe.throw(_("No stock items available to transfer"))
 
 	stock_entry.insert()
 	return stock_entry.name
+

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.py
@@ -118,8 +118,8 @@ def create_rfq_from_boq(source_name):
 @frappe.whitelist()
 def transfer_stock_to_project(boq_name):
 	"""
-	Create a Draft Stock Entry from BOQ and redirect user.
-	No stock movement or BOQ update happens here.
+	Create a Draft Stock Entry from BOQ
+	Qty fetched will never exceed available stock
 	"""
 
 	boq = frappe.get_doc("Bill of Quantity", boq_name)
@@ -164,16 +164,26 @@ def transfer_stock_to_project(boq_name):
 				_("Default Warehouse not set for Item {0}").format(row.item)
 			)
 
+		available_qty = frappe.db.get_value(
+			"Bin",
+			{"item_code": row.item, "warehouse": from_warehouse},
+			"actual_qty"
+		) or 0
+
+		transfer_qty = min(required_qty, available_qty)
+
+		if transfer_qty <= 0:
+			continue
+
 		stock_entry.append("items", {
 			"item_code": row.item,
-			"qty": required_qty,
+			"qty": transfer_qty,
 			"s_warehouse": from_warehouse,
 			"t_warehouse": project_warehouse
 		})
 
 	if not stock_entry.items:
-		frappe.throw(_("All items are already transferred"))
+		frappe.throw(_("No stock available to transfer"))
 
 	stock_entry.insert()
 	return stock_entry.name
-


### PR DESCRIPTION
- [x] TASK-2026-00169
- [x] TASK-2026-00171

## Feature description
Need to: 

- Ensures the Stock Entries created from BOQ always reflect actual stock availability and prevents over issuance.
- Skip stock availability check for Service Items in BOQ
- Skip Stock Availability Logic for Service Items

If an item is not a stock item:

   - No stock balance lookup is performed
   - No "additional quantity needed" is calculated
   - No RFQ shortage entries are generated
   - The item is not considered during stock transfer logic
   - Stock-related fields are reset to zero

## Solution description
During Stock Entry creation from a BOQ, the system dynamically fetches the current stock balance of each item from the Bin table (actual_qty) for the relevant source warehouse.

For each BOQ item:
- The remaining quantity to be transferred is calculated based on BOQ quantity and previously transferred quantity.
- The available stock is fetched in real time from the warehouse.
- The quantity added to the Stock Entry is restricted to the minimum of required quantity and available stock.
- Items with zero available stock are skipped.

Before any stock operation (stock balance fetch, additional qty calculation, RFQ creation, or stock transfer), the system now verifies:

     - Whether the selected item is a stock item
    - If not, the item is treated as a service/non-stock item

## Output screenshots (optional)
[Screencast from 29-01-26 12:25:16 PM IST.webm](https://github.com/user-attachments/assets/349a503a-1dd7-43d3-9a5a-bf997e43d098)


## Areas affected and ensured
Bill of quantity

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome

