### PR TITLE
TASK-2026-00099: create project from sales order

### DIFF
--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -11,6 +11,31 @@ def get_sales_order_custom_fields():
 				"label": "Bill of Quantity",
 				"insert_after": "order_type",
 			},
+			{
+				"fieldname": "section_break_project",
+				"fieldtype": "Section Break",
+				"label": "",
+				"insert_after": "reserve_stock",
+			},
+			{
+				"fieldname": "employee_group",
+				"fieldtype": "Link",
+				"options": "Employee Group",
+				"label": "Employee Group",
+				"insert_after": "section_break_project",
+			},
+			{
+				"fieldname": "column_break_project",
+				"fieldtype": "Column Break",
+				"label": "",
+				"insert_after": "employee_group",
+			},
+			{
+				"fieldname": "project_name",
+				"fieldtype": "Data",
+				"label": "Project Name",
+				"insert_after": "column_break_project",
+			},
 		]
 	}
 

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -50,6 +50,7 @@ doctype_js = {
 	"Delivery Note":"stems/custom_scripts/delivery_note/delivery_note.js",
     "Item":"stems/custom_scripts/item/item.js",
     "Task":"stems/custom_scripts/task/task.js",
+	"Sales Order":"stems/custom_scripts/sales_order/sales_order.js",
 }
 doctype_list_js = {
 	"Lead" : "stems/custom_scripts/lead/lead_list.js"
@@ -174,6 +175,9 @@ doc_events = {
 	"Stock Entry": {
 		"validate": "stems.stems.custom_scripts.stock_entry.stock_entry.validate_stock_entry_qty",
 		"on_submit": "stems.stems.custom_scripts.stock_entry.stock_entry.update_boq_transferred_qty",
+	},
+	"Sales Order": {
+		"on_submit": "stems.stems.custom_scripts.sales_order.sales_order.create_project_from_sales_order",
 	},
 }
 

--- a/stems/stems/custom_scripts/sales_order/sales_order.js
+++ b/stems/stems/custom_scripts/sales_order/sales_order.js
@@ -1,0 +1,70 @@
+frappe.ui.form.on('Sales Order', {
+	transaction_date: function(frm) {
+		calculate_item_delivery_dates(frm);
+	},
+	refresh: function(frm) {
+		calculate_item_delivery_dates(frm);
+	}
+});
+
+frappe.ui.form.on('Sales Order Item', {
+	item_code: function(frm, cdt, cdn) {
+		calculate_item_delivery_dates(frm);
+	},
+	items_add: function(frm) {
+		calculate_item_delivery_dates(frm);
+	},
+	items_remove: function(frm) {
+		calculate_item_delivery_dates(frm);
+	}
+});
+
+/**
+ * Calculates delivery dates for items based on their task template durations.
+ * Sets each item's delivery_date and updates parent delivery_date to the latest.
+ */
+function calculate_item_delivery_dates(frm) {
+	if (!frm.doc.transaction_date || !frm.doc.items?.length) return;
+
+	const HOURS_IN_DAY = 24;
+	let parent_latest_date = null;
+	let item_promises = [];
+
+	frm.doc.items.forEach(row => {
+		if (!row.item_code) return;
+
+		let item_promise = frappe.db.get_doc('Item', row.item_code).then(item_doc => {
+			let longest_days = 0;
+			let task_promises = [];
+			(item_doc.task_template || []).forEach(t => {
+				if (!t.task_templates) return;
+
+				let task_promise = frappe.db
+					.get_doc('Task', t.task_templates)
+					.then(task => {
+						if (task.expected_time) {
+							let days = task.expected_time / HOURS_IN_DAY;
+							longest_days = Math.max(longest_days, days);
+						}
+					});
+				task_promises.push(task_promise);
+			});
+			return Promise.all(task_promises).then(() => {
+				if (!longest_days) return;
+
+				let required_days = Math.ceil(longest_days);
+				let delivery_date = frappe.datetime.add_days(frm.doc.transaction_date,required_days);
+				frappe.model.set_value(row.doctype,row.name,"delivery_date",delivery_date);
+				if (!parent_latest_date || delivery_date > parent_latest_date) {
+					parent_latest_date = delivery_date;
+				}
+			});
+		});
+		item_promises.push(item_promise);
+	});
+	Promise.all(item_promises).then(() => {
+		if (parent_latest_date) {
+			frm.set_value("delivery_date", parent_latest_date);
+		}
+	});
+}

--- a/stems/stems/custom_scripts/sales_order/sales_order.py
+++ b/stems/stems/custom_scripts/sales_order/sales_order.py
@@ -1,0 +1,129 @@
+import frappe
+from frappe.utils import get_datetime
+from frappe.model.naming import make_autoname
+from frappe.desk.form.assign_to import add as add_assignment
+
+def generate_project_name(customer):
+	series = make_autoname("PROJ-.####")
+	serial = series.split("-")[-1]
+	return f"{frappe.scrub(customer).upper()}-{serial}"
+
+def get_task_templates_from_items(doc):
+	"""Get list of existing task names from Item's task_template child table"""
+	task_names = set()
+	for item in doc.items:
+		if not item.item_code:
+			continue
+		rows = frappe.get_all(
+			"Task Templates",
+			filters={"parent": item.item_code},
+			pluck="task_templates"
+		)
+		for task_name in rows:
+			if task_name:
+				task_names.add(task_name)
+	return list(task_names)
+
+def assign_existing_tasks_to_project(project, doc):
+	"""Link existing tasks from item templates to project and assign to employee group users"""
+	task_names = get_task_templates_from_items(doc)
+	if not task_names:
+		return
+	
+	assignees = get_employee_group_users(doc.employee_group) if doc.employee_group else []
+	for task_name in task_names:
+		try:
+			task = frappe.get_doc("Task", task_name)
+			task.project = project.name
+			task.save(ignore_permissions=True)
+			
+			for user in assignees:
+				try:
+					add_assignment({
+						"assign_to": user,
+						"doctype": "Task",
+						"name": task_name,
+						"description": f"Task assigned from Sales Order {doc.name}"
+					})
+				except Exception as e:
+					frappe.log_error(f"Failed to assign task {task_name} to {user}: {str(e)}")
+		except Exception as e:
+			frappe.log_error(f"Failed to link task {task_name} to project: {str(e)}")
+
+def create_project_from_sales_order(doc, method=None):
+	"""Create a Project from Sales Order on submission"""
+	if doc.project:
+		return
+	
+	project_name = doc.project_name or generate_project_name(doc.customer)
+	expected_end_date = doc.delivery_date
+	project = frappe.get_doc({
+		"doctype": "Project",
+		"project_name": project_name,
+		"customer": doc.customer,
+		"sales_order": doc.name,
+		"expected_start_date": doc.transaction_date,
+		"expected_end_date": expected_end_date,
+	}).insert(ignore_permissions=True)
+	
+	assign_existing_tasks_to_project(project, doc)
+	assign_project_to_employee_group(project, doc)
+	send_project_notification(project, doc)
+
+def assign_project_to_employee_group(project, doc):
+	"""Assign the project itself to all users in the employee group"""
+	if not doc.employee_group:
+		return
+	
+	employee_group = frappe.get_doc("Employee Group", doc.employee_group)
+	for row in employee_group.employee_list:
+		if not row.user_id:
+			continue
+		try:
+			add_assignment({
+				"assign_to": [row.user_id],
+				"doctype": "Project",
+				"name": project.name,
+				"description": f"Project assigned from Sales Order {doc.name}"
+			})
+		except Exception as e:
+			frappe.log_error(f"Failed to assign project to {row.user_id}: {str(e)}")
+
+def send_project_notification(project, doc):
+	"""Send email notification to employee group users"""
+	template_name = frappe.get_single_value("STEMS Settings", "project_assignment_notification")
+	if not template_name:
+		return
+	
+	try:
+		template = frappe.get_doc("Email Template", template_name)        
+		context = {
+			"project": project,
+			"sales_order": doc,
+		}
+		
+		subject = frappe.render_template(template.subject, context)
+		message = frappe.render_template(template.response, context)
+		
+		recipients = get_employee_group_users(doc.employee_group)
+		if not recipients:
+			return
+		
+		frappe.sendmail(
+			recipients=recipients,
+			subject=subject,
+			message=message
+		)
+	except Exception as e:
+		frappe.log_error(
+			title="Failed to send project notification",
+			message=frappe.get_traceback()
+		)
+
+def get_employee_group_users(employee_group):
+	"""Get list of user IDs from employee group"""
+	if not employee_group:
+		return []
+	
+	group = frappe.get_doc("Employee Group", employee_group)
+	return [row.user_id for row in group.employee_list if row.user_id]

--- a/stems/stems/doctype/stems_settings/stems_settings.json
+++ b/stems/stems/doctype/stems_settings/stems_settings.json
@@ -11,6 +11,8 @@
   "enable_quotation_follow_up",
   "follow_up_notification_template",
   "follow_up_days",
+  "enable_sales_order_notification",
+  "project_assignment_notification",
   "column_break_zbaj",
   "quotation_print_format",
   "enable_opportunity_activity_notification",
@@ -123,13 +125,27 @@
    "fieldtype": "Link",
    "label": "Payment Task Notification Role",
    "options": "Role"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_sales_order_notification",
+   "fieldtype": "Check",
+   "label": "Enable Sales Order Notification"
+  },
+  {
+   "depends_on": "eval:doc.enable_sales_order_notification",
+   "description": "Template used to notify when a project is assigned to an employee group.",
+   "fieldname": "project_assignment_notification",
+   "fieldtype": "Link",
+   "label": "Project Assignment Notification",
+   "options": "Email Template"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-22 17:12:14.255184",
+ "modified": "2026-01-30 10:20:39.997567",
  "modified_by": "Administrator",
  "module": "STEMS",
  "name": "STEMS Settings",


### PR DESCRIPTION
## Feature description
create and assign a Project from a submitted Sales Order, including task linking, employee group assignment, delivery date calculation, and email notifications.
## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
- Added custom fields in Sales Order for Employee Group and Project Name.
- Implemented client-side logic to auto-calculate item and parent delivery dates based on linked task templates.
- Added server-side hook to auto-create a Project on Sales Order submission.
- Linked existing template-based Tasks to the created Project.
- Assigned Project and Tasks to users from the selected Employee Group.
- Added configurable email notification using Email Templates via STEMS Settings.

## Output screenshots (optional)
<img width="1838" height="934" alt="image" src="https://github.com/user-attachments/assets/4a59a420-e783-4d6a-82c7-4cb1cff30e41" />
<img width="1838" height="934" alt="image" src="https://github.com/user-attachments/assets/94787a7c-6d58-4727-b68f-b183de26e7b6" />
<img width="1838" height="934" alt="image" src="https://github.com/user-attachments/assets/f585fc5c-38e8-430b-9cfa-92b3964cf4c0" />

## Areas affected and ensured

- Sales Order (custom fields and client scripts)
- Project creation and assignment
- Task linking and assignment
- STEMS Settings (email template configuration)
- Email notification

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
