### PR TITLE
TASK-2026-00179:Update Additional Quantity Needed count when stock transfer is done

### DIFF
--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('Bill of Quantity', {
 			add_make_quotation_button(frm);
 			add_create_rfq_button(frm);
 		}
-        if (frm.doc.project && frm.doc.docstatus === 1) {
+		if (frm.doc.project && frm.doc.docstatus === 1) {
 			add_transfer_stock_button(frm);
 		}
 	},
@@ -101,10 +101,18 @@ function calculate_additional_qty(frm, cdt, cdn) {
 	}
 
 	frappe.db.get_value('Item', row.item, 'is_stock_item', (r) => {
+
 		if (!r || !r.is_stock_item || !row.qty || row.customer_provided) {
 			row.additional_quantity_needed = 0;
 		} else {
-			let shortage = row.qty - (row.stock_balance || 0);
+
+			let qty = row.qty || 0;
+			let transferred_qty = row.transferred_quantity || 0;
+			let stock_balance = row.stock_balance || 0;
+
+			let remaining_qty = qty - transferred_qty;
+			if (remaining_qty < 0) remaining_qty = 0;
+			let shortage = remaining_qty - stock_balance;
 			row.additional_quantity_needed = shortage > 0 ? shortage : 0;
 		}
 		frm.refresh_field("items");


### PR DESCRIPTION
## Feature description
Need to: Update Additional Quantity Needed count when stock transfer is done

## Solution description
Updated Additional Quantity Needed for each item in the items table od BOQby correctly considering:
Total Required Quantity (qty)
Quantity Already Transferred to the Project (transferred_quantity)
Available Stock in Warehouse (stock_balance)

## Output screenshots (optional)

[Screencast from 30-01-26 05:01:45 PM IST.webm](https://github.com/user-attachments/assets/4f1d5125-8d75-4188-8849-9f5b50fa5ac1)

[Screencast from 30-01-26 05:03:16 PM IST.webm](https://github.com/user-attachments/assets/4f1f6bc3-0c35-43f1-be2a-a83699ab14ff)

[Screencast from 30-01-26 05:05:09 PM IST.webm](https://github.com/user-attachments/assets/f14b3507-3e28-471b-ab24-1837810fa978)


## Areas affected and ensured
List out the areas affected by your code changes.

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
