### PR TITLE
TASK-2026-00105:Prevent auto update of stock balance in BOQ

### DIFF
--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -177,7 +177,10 @@ doc_events = {
 	},
 	"Stock Entry": {
 		"validate": "stems.stems.custom_scripts.stock_entry.stock_entry.validate_stock_entry_qty",
-		"on_submit": "stems.stems.custom_scripts.stock_entry.stock_entry.update_boq_transferred_qty",
+		"on_submit": [
+			"stems.stems.custom_scripts.stock_entry.stock_entry.update_boq_transferred_qty",
+			"stems.stems.custom_scripts.stock_entry.stock_entry.freeze_stock_balance_when_completed",
+		],
 	},
 	"Sales Order": {
 		"on_submit": "stems.stems.custom_scripts.sales_order.sales_order.create_project_from_sales_order",

--- a/stems/stems/custom_scripts/stock_entry/stock_entry.py
+++ b/stems/stems/custom_scripts/stock_entry/stock_entry.py
@@ -34,15 +34,66 @@ def validate_stock_entry_qty(doc, method):
 
 def update_boq_transferred_qty(doc, method):
 	"""
-		Update the transferred quantity in BOQ items after Stock Entry submission.
+	Update transferred qty in BOQ, but do NOT allow exceeding qty.
 	"""
 	if doc.stock_entry_type != "Material Transfer":
 		return
 
 	for item in doc.items:
-		frappe.db.sql("""
-			UPDATE `tabBill of Quantity Item`
-			SET transferred_quantity = IFNULL(transferred_quantity, 0) + %s
-			WHERE item = %s
-		""", (item.qty, item.item_code))
+		boq_item = frappe.db.get_value(
+			"Bill of Quantity Item",
+			{"item": item.item_code},
+			["name", "qty", "transferred_quantity"],
+			as_dict=True
+		)
 
+		if not boq_item:
+			continue
+
+		existing = boq_item.transferred_quantity or 0
+		new_total = existing + item.qty
+
+		if new_total > boq_item.qty:
+			new_total = boq_item.qty
+
+		frappe.db.set_value(
+			"Bill of Quantity Item",
+			boq_item.name,
+			"transferred_quantity",
+			new_total
+		)
+
+def freeze_stock_balance_when_completed(doc, method):
+	"""
+	Freeze stock_balance only when transferred_quantity == qty.
+	Material Receipt should not modify stock_balance.
+	"""
+	if doc.stock_entry_type != "Material Transfer":
+		return
+
+	for item in doc.items:
+		boq_item = frappe.db.get_value(
+			"Bill of Quantity Item",
+			{"item": item.item_code},
+			["name", "qty", "transferred_quantity", "stock_balance"],
+			as_dict=True
+		)
+
+		if not boq_item:
+			continue
+
+		if boq_item.transferred_quantity == boq_item.qty:
+			current_stock = frappe.db.get_value(
+				"Bin",
+				{"item_code": item.item_code, "warehouse": item.s_warehouse},
+				"actual_qty"
+			) or 0
+
+			new_balance = current_stock
+
+			frappe.db.set_value(
+				"Bill of Quantity Item",
+				boq_item.name,
+				"stock_balance",
+				new_balance
+			)

--- a/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
+++ b/stems/stems/doctype/bill_of_quantity/bill_of_quantity.js
@@ -15,6 +15,7 @@ frappe.ui.form.on('Bill of Quantity', {
 		show_additional_stock_message(frm);
 	},
 	onload : function(frm) {
+		if (frm.doc.docstatus === 1) return;
 		frm.doc.items.forEach(function(row, index) {
 			stock_balance_fetch(frm, 'Bill of Quantity Item', row.name);
 		});
@@ -35,6 +36,7 @@ function add_make_quotation_button(frm) {
 
 frappe.ui.form.on('Bill of Quantity Item', {
 	item: function(frm, cdt, cdn) {
+		if (frm.doc.docstatus === 1) return;
 		stock_balance_fetch(frm, cdt, cdn);
 	},
 	qty: function(frm, cdt, cdn) {   


### PR DESCRIPTION
## Feature description
Need to: 

- Material Transfer Stock Entries update only transferred_quantity in BOQ Items.
- stock_balance should not change automatically on Material Transfer.
- Freeze logic only applies when transferred_quantity equals BOQ qty.
- Other Stock Entry types (like Material Receipt or Adjustment) do not affect BOQ stock balance.

## Solution description

- Update transferred quantity:
   - When stock is transferred, the BOQ item’s transferred_quantity is updated.
   - It never goes above the original BOQ quantity.

- Freeze stock balance:
   - stock_balance stays the same during transfers.
   - Only when an item’s transferred quantity equals BOQ quantity, the stock balance is frozen.

- Front-end changes:
- After BOQ submission, stock balances are not fetched again to avoid overwriting frozen values.

- Result:

   - BOQ shows planned stock and transferred quantities correctly.

   - Stock transfers don’t change BOQ balances accidentally.

## Output screenshots (optional)
[Screencast from 03-02-26 05:12:49 PM IST.webm](https://github.com/user-attachments/assets/b5fb8724-4515-4668-a155-aa43806c0d42)

[Screencast from 03-02-26 05:14:18 PM IST.webm](https://github.com/user-attachments/assets/1365a2d7-626d-4799-a71e-fdba751e150d)

[Screencast from 03-02-26 05:15:16 PM IST.webm](https://github.com/user-attachments/assets/d1663e3e-936b-48af-ab1b-d4eeb68e5d2a)


## Areas affected and ensured
Bill of quantity

## Is there any existing behavior change of other features due to this code change?
 No.

## Was this feature tested on the browsers?
  - Chrome
 
