### PR TITLE
TASK-2026-00231: add item-wise percentage for partial invoicing

### DIFF
--- a/stems/custom/custom_field/sales_invoice.py
+++ b/stems/custom/custom_field/sales_invoice.py
@@ -1,0 +1,22 @@
+def get_sales_invoice_custom_fields():
+	"""
+	Custom fields for Sales Invoice (and child) for percentage invoicing from Sales Order.
+	"""
+	return {
+		"Sales Invoice Item": [
+			{
+				"fieldname": "billed_percentage",
+				"fieldtype": "Percent",
+				"label": "Billed %",
+				"insert_after": "amount",
+				"read_only": 1,
+			},
+			{
+				"fieldname": "remaining_percentage",
+				"fieldtype": "Percent",
+				"label": "Remaining %",
+				"insert_after": "billed_percentage",
+				"read_only": 1,
+			},
+		]
+	}

--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -1,8 +1,26 @@
 def get_sales_order_custom_fields():
 	"""
-	Custom fields that need to be added to the Sales Order DocType
+	Custom fields that need to be added to the Sales Order DocType and its child table.
 	"""
 	return {
+		"Sales Order Item": [
+			{
+				"fieldname": "invoiced_amount",
+				"fieldtype": "Currency",
+				"label": "Invoiced Amount",
+				"insert_after": "amount",
+				"read_only": 1,
+				"description": "Total amount invoiced against this line from Sales Invoices (updated when an SI is submitted).",
+			},
+			{
+				"fieldname": "remaining_amount",
+				"fieldtype": "Currency",
+				"label": "Remaining Amount",
+				"insert_after": "invoiced_amount",
+				"read_only": 1,
+				"description": "Amount yet to be invoiced (Total - Invoiced).",
+			},
+		],
 		"Sales Order": [
 			{
 				"fieldname": "bill_of_quantity",

--- a/stems/custom/custom_field/sales_order.py
+++ b/stems/custom/custom_field/sales_order.py
@@ -37,6 +37,19 @@ def get_sales_order_custom_fields():
 				"insert_after": "column_break_project",
 			},
 			{
+				"fieldname": "enable_percentage_invoicing",
+				"fieldtype": "Check",
+				"label": "Enable Percentage-Based Invoicing",
+				"insert_after": "project_name",
+				"description": "When checked, Create Sales Invoice opens a popup to enter % and select items (partial invoicing).",
+			},
+			{
+				"fieldname": "percentage_invoicing_status",
+				"fieldtype": "HTML",
+				"label": "",
+				"insert_after": "enable_percentage_invoicing",
+			},
+			{
 				"fieldname": "task_wise_payment_summary",
 				"fieldtype": "Section Break",
 				"label": "Task Wise Payment Summary",

--- a/stems/hooks.py
+++ b/stems/hooks.py
@@ -183,7 +183,18 @@ doc_events = {
 		],
 	},
 	"Sales Order": {
-		"on_submit": "stems.stems.custom_scripts.sales_order.sales_order.create_project_from_sales_order",
+		"on_submit": [
+			"stems.stems.custom_scripts.sales_order.sales_order.create_project_from_sales_order",
+			"stems.stems.custom_scripts.sales_order.percentage_invoicing.set_initial_so_item_amounts",
+		],
+	},
+	"Sales Invoice": {
+		"on_submit": [
+			"stems.stems.custom_scripts.sales_order.percentage_invoicing.update_so_item_invoiced_amounts",
+		],
+		"on_cancel": [
+			"stems.stems.custom_scripts.sales_order.percentage_invoicing.update_so_item_invoiced_amounts",
+		],
 	},
 }
 

--- a/stems/stems/custom_scripts/sales_order/percentage_invoicing.py
+++ b/stems/stems/custom_scripts/sales_order/percentage_invoicing.py
@@ -1,127 +1,199 @@
+"""
+Percentage-based invoicing for Sales Order.
+Service items: percentage on amount (rate adjusted). Stock items: percentage on qty.
+Supports one percentage for the order or per-item percentage in the popup.
+"""
+
 import frappe
 from frappe import _
 from frappe.utils import flt
-
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+
+
+def _get_billed_qty_and_amount(sales_order_name, so_detail):
+	""" Returns the total billed quantity and amount for a given sales order item detail."""
+	result = frappe.db.sql(
+		"""
+		SELECT SUM(sii.qty), SUM(sii.amount)
+		FROM `tabSales Invoice Item` sii
+		INNER JOIN `tabSales Invoice` si ON si.name = sii.parent
+		WHERE sii.sales_order = %s AND sii.so_detail = %s AND si.docstatus = 1
+		""",
+		(sales_order_name, so_detail),
+	)
+	if not result or not result[0]:
+		return 0, 0
+	return flt(result[0][0]), flt(result[0][1])
+
+
+def update_so_item_invoiced_amounts(sales_invoice, method=None):
+	""" Updates the invoiced and remaining amounts for sales order items linked to the given sales invoice."""
+	if sales_invoice.docstatus not in (1, 2):
+		return
+	so_items = [
+		(item.get("sales_order"), item.get("so_detail"))
+		for item in (sales_invoice.items or [])
+		if item.get("sales_order") and item.get("so_detail")
+	]
+	if not so_items:
+		return
+	so_to_details = {}
+	for so_name, so_detail in so_items:
+		so_to_details.setdefault(so_name, set()).add(so_detail)
+	for so_name, so_details in so_to_details.items():
+		for so_detail in so_details:
+			invoiced = frappe.db.sql(
+				"""
+				SELECT SUM(sii.amount)
+				FROM `tabSales Invoice Item` sii
+				INNER JOIN `tabSales Invoice` si ON si.name = sii.parent
+				WHERE sii.sales_order = %s AND sii.so_detail = %s AND si.docstatus = 1
+				""",
+				(so_name, so_detail),
+			)
+			invoiced_amt = flt(invoiced[0][0] if invoiced and invoiced[0] else 0)
+			so_item = frappe.db.get_value(
+				"Sales Order Item",
+				so_detail,
+				["qty", "rate", "parent"],
+				as_dict=True,
+			)
+			if not so_item:
+				continue
+			total_amt = flt(so_item.qty) * flt(so_item.rate)
+			remaining_amt = max(0, total_amt - invoiced_amt)
+			frappe.db.set_value(
+				"Sales Order Item",
+				so_detail,
+				{"invoiced_amount": invoiced_amt, "remaining_amount": remaining_amt},
+			)
+	frappe.db.commit()
+
+
+def set_initial_so_item_amounts(sales_order, method=None):
+	""" Initializes the invoiced and remaining amounts for sales order items when a sales order is submitted."""
+	if sales_order.docstatus != 1:
+		return
+	for row in sales_order.items:
+		total_amt = flt(row.qty) * flt(row.rate)
+		frappe.db.set_value(
+			"Sales Order Item",
+			row.name,
+			{"invoiced_amount": 0, "remaining_amount": total_amt},
+		)
+	frappe.db.commit()
 
 
 @frappe.whitelist()
 def get_so_items(sales_order):
-	"""
-	Get Sales Order items with billed and remaining qty and percentage for percentage invoicing
-	"""
-
+	""" Retrieves the sales order items along with their billed and remaining quantities and amounts for percentage invoicing."""
 	so = frappe.get_doc("Sales Order", sales_order)
-
 	data = []
-
 	for row in so.items:
-
-		# Get billed qty properly
-		billed_qty = frappe.db.sql("""
-			SELECT SUM(sii.qty)
-			FROM `tabSales Invoice Item` sii
-			INNER JOIN `tabSales Invoice` si ON si.name = sii.parent
-			WHERE sii.sales_order = %s
-			AND sii.so_detail = %s
-			AND si.docstatus = 1
-		""", (so.name, row.name))[0][0] or 0
-
-		billed_qty = flt(billed_qty)
+		billed_qty, billed_amt = _get_billed_qty_and_amount(so.name, row.name)
 		total_qty = flt(row.qty)
-
-		remaining_qty = total_qty - billed_qty
-
-		if remaining_qty < 0:
-			remaining_qty = 0
-
-		if total_qty > 0:
-			remaining_percentage = (remaining_qty / total_qty) * 100
+		total_rate = flt(row.rate)
+		total_amt = total_qty * total_rate
+		stored_invoiced = row.get("invoiced_amount")
+		stored_remaining = row.get("remaining_amount")
+		if stored_invoiced is not None or stored_remaining is not None:
+			invoiced_amt = flt(stored_invoiced)
+			remaining_amt = flt(stored_remaining)
+			if remaining_amt <= 0 and total_amt > 0:
+				remaining_amt = max(0, total_amt - invoiced_amt)
 		else:
-			remaining_percentage = 0
-
+			invoiced_amt = billed_amt
+			remaining_amt = max(0, total_amt - billed_amt)
+		remaining_qty = max(0, total_qty - billed_qty)
+		remaining_qty_pct = (remaining_qty / total_qty * 100) if total_qty else 0
+		remaining_amt_pct = (remaining_amt / total_amt * 100) if total_amt else 0
 		is_stock = frappe.db.get_value("Item", row.item_code, "is_stock_item") or 0
-
+		item_type = "Stock" if is_stock else "Service"
+		has_remaining = remaining_qty > 0 or remaining_amt > 0
 		data.append({
 			"so_detail": row.name,
 			"item_code": row.item_code,
 			"qty": total_qty,
 			"billed_qty": billed_qty,
 			"remaining_qty": remaining_qty,
-			"remaining_percentage": round(remaining_percentage, 2),
-			"rate": flt(row.rate),
-			"item_type": "Stock" if is_stock else "Service",
-			"include": 1 if remaining_qty > 0 else 0
+			"remaining_qty_percentage": round(remaining_qty_pct, 2),
+			"rate": total_rate,
+			"total_amt": total_amt,
+			"billed_amt": invoiced_amt,
+			"remaining_amt": remaining_amt,
+			"invoiced_amount": invoiced_amt,
+			"remaining_amt_percentage": round(remaining_amt_pct, 2),
+			"item_type": item_type,
+			"include": 1 if has_remaining else 0,
 		})
-
 	return data
-
 
 
 @frappe.whitelist()
 def make_sales_invoice_by_percentage(source_name, target_doc=None):
-	"""
-	Make Sales Invoice by % of Sales Order
-	"""
-
+	""" Creates a sales invoice from a sales order based on the specified percentage for invoicing."""
 	args = frappe.parse_json(frappe.form_dict.get("args") or "{}")
-
 	percentage = flt(args.get("percentage"))
+	apply_to_all = args.get("apply_to_all", True)
 	selected_items = args.get("selected_items") or []
-
-	if not percentage or percentage <= 0:
-		frappe.throw(_("Invalid Percentage"))
-
+	if not selected_items:
+		frappe.throw(_("Select at least one item"))
 	so = frappe.get_doc("Sales Order", source_name)
-
 	if so.docstatus != 1:
 		frappe.throw(_("Sales Order must be submitted"))
-
-	# Header billed %
 	per_billed = flt(so.per_billed or 0)
-	remaining = 100 - per_billed
-
-	if percentage > remaining:
-		frappe.throw(_("Only {0}% remaining").format(remaining))
-
+	remaining_overall_pct = 100 - per_billed
+	if apply_to_all:
+		if not percentage or percentage <= 0:
+			frappe.throw(_("Invalid Percentage"))
+		if percentage > remaining_overall_pct:
+			frappe.throw(_("Only {0}% remaining overall").format(remaining_overall_pct))
 	selected_map = {d["so_detail"]: d for d in selected_items}
-
 	si = make_sales_invoice(source_name, target_doc)
-
 	new_items = []
-
 	for item in si.items:
-
 		if item.so_detail not in selected_map:
 			continue
-
+		sel = selected_map[item.so_detail]
 		so_row = next((x for x in so.items if x.name == item.so_detail), None)
-
 		if not so_row:
 			continue
-
-		item_type = selected_map[item.so_detail]["item_type"]
-
-		if item_type == "Stock":
-			# Apply % on QTY
-			new_qty = flt(so_row.qty * percentage / 100, item.precision("qty"))
-			item.qty = new_qty
-			item.rate = so_row.rate
-
+		item_type = sel.get("item_type") or "Stock"
+		total_qty = flt(so_row.qty)
+		total_rate = flt(so_row.rate)
+		total_amt = total_qty * total_rate
+		billed_qty = flt(sel.get("billed_qty") or 0)
+		billed_amt = flt(sel.get("billed_amt") or 0)
+		remaining_qty = flt(sel.get("remaining_qty") or max(0, total_qty - billed_qty))
+		remaining_amt = flt(sel.get("remaining_amt") or max(0, total_amt - billed_amt))
+		if apply_to_all:
+			fraction = (percentage / remaining_overall_pct) if remaining_overall_pct else 0
 		else:
-			# Apply % on RATE
-			new_rate = flt(so_row.rate * percentage / 100, item.precision("rate"))
-			item.qty = so_row.qty
-			item.rate = new_rate
-
+			item_percentage = flt(sel.get("percentage"))
+			if not item_percentage or item_percentage <= 0:
+				continue
+			fraction = min(1.0, item_percentage / 100.0)
+		if item_type == "Stock":
+			if remaining_qty <= 0:
+				continue
+			qty_to_bill = flt(remaining_qty * fraction, item.precision("qty"))
+			qty_to_bill = min(qty_to_bill, remaining_qty)
+			if qty_to_bill <= 0:
+				continue
+			item.qty = qty_to_bill
+			item.rate = total_rate
+		else:
+			if remaining_amt <= 0:
+				continue
+			amt_to_bill = flt(remaining_amt * fraction, item.precision("amount"))
+			amt_to_bill = min(amt_to_bill, remaining_amt)
+			if amt_to_bill <= 0:
+				continue
+			item.qty = total_qty
+			item.rate = (amt_to_bill / total_qty) if total_qty else 0
 		new_items.append(item)
-
 	if not new_items:
-		frappe.throw(_("No items selected"))
-
+		frappe.throw(_("No items left to invoice"))
 	si.set("items", new_items)
-
 	si.calculate_taxes_and_totals()
-
 	return si
-

--- a/stems/stems/custom_scripts/sales_order/percentage_invoicing.py
+++ b/stems/stems/custom_scripts/sales_order/percentage_invoicing.py
@@ -1,0 +1,127 @@
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+
+
+@frappe.whitelist()
+def get_so_items(sales_order):
+	"""
+	Get Sales Order items with billed and remaining qty and percentage for percentage invoicing
+	"""
+
+	so = frappe.get_doc("Sales Order", sales_order)
+
+	data = []
+
+	for row in so.items:
+
+		# Get billed qty properly
+		billed_qty = frappe.db.sql("""
+			SELECT SUM(sii.qty)
+			FROM `tabSales Invoice Item` sii
+			INNER JOIN `tabSales Invoice` si ON si.name = sii.parent
+			WHERE sii.sales_order = %s
+			AND sii.so_detail = %s
+			AND si.docstatus = 1
+		""", (so.name, row.name))[0][0] or 0
+
+		billed_qty = flt(billed_qty)
+		total_qty = flt(row.qty)
+
+		remaining_qty = total_qty - billed_qty
+
+		if remaining_qty < 0:
+			remaining_qty = 0
+
+		if total_qty > 0:
+			remaining_percentage = (remaining_qty / total_qty) * 100
+		else:
+			remaining_percentage = 0
+
+		is_stock = frappe.db.get_value("Item", row.item_code, "is_stock_item") or 0
+
+		data.append({
+			"so_detail": row.name,
+			"item_code": row.item_code,
+			"qty": total_qty,
+			"billed_qty": billed_qty,
+			"remaining_qty": remaining_qty,
+			"remaining_percentage": round(remaining_percentage, 2),
+			"rate": flt(row.rate),
+			"item_type": "Stock" if is_stock else "Service",
+			"include": 1 if remaining_qty > 0 else 0
+		})
+
+	return data
+
+
+
+@frappe.whitelist()
+def make_sales_invoice_by_percentage(source_name, target_doc=None):
+	"""
+	Make Sales Invoice by % of Sales Order
+	"""
+
+	args = frappe.parse_json(frappe.form_dict.get("args") or "{}")
+
+	percentage = flt(args.get("percentage"))
+	selected_items = args.get("selected_items") or []
+
+	if not percentage or percentage <= 0:
+		frappe.throw(_("Invalid Percentage"))
+
+	so = frappe.get_doc("Sales Order", source_name)
+
+	if so.docstatus != 1:
+		frappe.throw(_("Sales Order must be submitted"))
+
+	# Header billed %
+	per_billed = flt(so.per_billed or 0)
+	remaining = 100 - per_billed
+
+	if percentage > remaining:
+		frappe.throw(_("Only {0}% remaining").format(remaining))
+
+	selected_map = {d["so_detail"]: d for d in selected_items}
+
+	si = make_sales_invoice(source_name, target_doc)
+
+	new_items = []
+
+	for item in si.items:
+
+		if item.so_detail not in selected_map:
+			continue
+
+		so_row = next((x for x in so.items if x.name == item.so_detail), None)
+
+		if not so_row:
+			continue
+
+		item_type = selected_map[item.so_detail]["item_type"]
+
+		if item_type == "Stock":
+			# Apply % on QTY
+			new_qty = flt(so_row.qty * percentage / 100, item.precision("qty"))
+			item.qty = new_qty
+			item.rate = so_row.rate
+
+		else:
+			# Apply % on RATE
+			new_rate = flt(so_row.rate * percentage / 100, item.precision("rate"))
+			item.qty = so_row.qty
+			item.rate = new_rate
+
+		new_items.append(item)
+
+	if not new_items:
+		frappe.throw(_("No items selected"))
+
+	si.set("items", new_items)
+
+	si.calculate_taxes_and_totals()
+
+	return si
+

--- a/stems/stems/custom_scripts/sales_order/sales_order.js
+++ b/stems/stems/custom_scripts/sales_order/sales_order.js
@@ -6,6 +6,15 @@ frappe.ui.form.on('Sales Order', {
 		calculate_item_delivery_dates(frm);
 		allow_task_table_edit_after_submit(frm);
 
+        if (!frm.doc.enable_percentage_invoicing) return;
+		if (frm.doc.docstatus !== 1) return;
+
+		// Remove default Create Invoice button
+		frm.remove_custom_button(__('Sales Invoice'), __('Create'));
+
+		frm.add_custom_button(__('Sales Invoice'), function () {
+			open_percentage_dialog(frm);
+		}, __('Create'));
 	}
 });
 
@@ -117,3 +126,100 @@ function recalculate_task_amount(frm, cdt, cdn) {
 
 	frappe.model.set_value(cdt,cdn,"amount",(total * percentage) / 100);
 }
+
+
+
+// ========================= Percentage Invoicing Logic =========================
+function open_percentage_dialog(frm) {
+
+	let remaining = 100 - flt(frm.doc.per_billed || 0);
+
+	if (remaining <= 0) {
+		frappe.msgprint("Sales Order already fully invoiced.");
+		return;
+	}
+
+	frappe.call({
+		method: "stems.stems.custom_scripts.sales_order.percentage_invoicing.get_so_items",
+		args: { sales_order: frm.doc.name },
+		callback: function (r) {
+
+			let items = r.message || [];
+
+			let d = new frappe.ui.Dialog({
+				title: "Create Percentage Invoice",
+				size: "large",
+				fields: [
+
+					{
+						fieldname: "percentage",
+						fieldtype: "Float",
+						label: "Invoice Percentage",
+						reqd: 1,
+						default: remaining
+					},
+
+					{
+						fieldname: "items",
+						fieldtype: "Table",
+						label: "Items",
+						in_place_edit: true,
+						data: items,
+						fields: [
+                                    { fieldname: "include", fieldtype: "Check", label: "Include", in_list_view: 1 },
+                                    { fieldname: "so_detail", fieldtype: "Data", hidden: 1 },
+
+                                    { fieldname: "item_code", fieldtype: "Data", label: "Item", in_list_view: 1, read_only: 1 },
+
+                                    { fieldname: "qty", fieldtype: "Float", label: "Total Qty", in_list_view: 1, read_only: 1 },
+                                    { fieldname: "billed_qty", fieldtype: "Float", label: "Billed Qty", in_list_view: 1, read_only: 1 },
+                                    { fieldname: "remaining_qty", fieldtype: "Float", label: "Remaining Qty", in_list_view: 1, read_only: 1 },
+
+                                    { fieldname: "remaining_percentage", fieldtype: "Float", label: "Remaining %", in_list_view: 1, read_only: 1 },
+
+                                    { fieldname: "rate", fieldtype: "Currency", label: "Rate", in_list_view: 1, read_only: 1 }
+                                ]
+					}
+				],
+
+				primary_action_label: "Create Invoice",
+
+				primary_action(values) {
+
+					let pct = flt(values.percentage);
+
+					if (!(pct > 0 && pct <= 100)) {
+						frappe.msgprint("Enter percentage between 1 and 100.");
+						return;
+					}
+
+					if (pct > remaining) {
+						frappe.msgprint("Only " + remaining + "% remaining overall.");
+						return;
+					}
+
+					let selected = (values.items || []).filter(i => i.include);
+
+					if (!selected.length) {
+						frappe.msgprint("Select at least one item.");
+						return;
+					}
+
+					d.hide();
+
+					frappe.model.open_mapped_doc({
+						method: "stems.stems.custom_scripts.sales_order.percentage_invoicing.make_sales_invoice_by_percentage",
+						frm: frm,
+						args: {
+							percentage: pct,
+							selected_items: selected
+						}
+					});
+				}
+			});
+
+			d.show();
+		}
+	});
+}
+

--- a/stems/stems/custom_scripts/sales_order/sales_order.js
+++ b/stems/stems/custom_scripts/sales_order/sales_order.js
@@ -128,14 +128,13 @@ function recalculate_task_amount(frm, cdt, cdn) {
 }
 
 
-
-// ========================= Percentage Invoicing Logic =========================
+// Opens a dialog to create a percentage invoice for the sales order
 function open_percentage_dialog(frm) {
 
 	let remaining = 100 - flt(frm.doc.per_billed || 0);
 
 	if (remaining <= 0) {
-		frappe.msgprint("Sales Order already fully invoiced.");
+		frappe.msgprint(__("Sales Order already fully invoiced."));
 		return;
 	}
 
@@ -145,64 +144,77 @@ function open_percentage_dialog(frm) {
 		callback: function (r) {
 
 			let items = r.message || [];
+			let item_fields = [
+				{ fieldname: "include", fieldtype: "Check", label: __("Include"), in_list_view: 1 },
+				{ fieldname: "so_detail", fieldtype: "Data", hidden: 1 },
+				{ fieldname: "item_code", fieldtype: "Data", label: __("Item"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "item_type", fieldtype: "Data", label: __("Type"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "qty", fieldtype: "Float", label: __("Total Qty"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "billed_qty", fieldtype: "Float", label: __("Billed Qty"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "remaining_qty", fieldtype: "Float", label: __("Remaining Qty"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "rate", fieldtype: "Currency", label: __("Rate"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "total_amt", fieldtype: "Currency", label: __("Total Amt"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "invoiced_amount", fieldtype: "Currency", label: __("Invoiced Amount"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "remaining_amt", fieldtype: "Currency", label: __("Remaining Amount"), in_list_view: 1, read_only: 1 },
+				{ fieldname: "percentage", fieldtype: "Float", label: __("Percentage"), in_list_view: 1 }
+			];
 
 			let d = new frappe.ui.Dialog({
-				title: "Create Percentage Invoice",
+				title: __("Create Percentage Invoice"),
 				size: "large",
 				fields: [
-
+					{
+						fieldname: "apply_to_all",
+						fieldtype: "Check",
+						label: __("Apply percentage to all items"),
+						default: 1,
+						description: __("If unchecked, set percentage per item in the table.")
+					},
 					{
 						fieldname: "percentage",
 						fieldtype: "Float",
-						label: "Invoice Percentage",
-						reqd: 1,
-						default: remaining
+						label: __("Invoice Percentage"),
+						default: remaining,
+						description: __("Percentage of the order to bill in this invoice (when applying to all).")
 					},
-
 					{
 						fieldname: "items",
 						fieldtype: "Table",
-						label: "Items",
+						label: __("Items"),
 						in_place_edit: true,
 						data: items,
-						fields: [
-                                    { fieldname: "include", fieldtype: "Check", label: "Include", in_list_view: 1 },
-                                    { fieldname: "so_detail", fieldtype: "Data", hidden: 1 },
-
-                                    { fieldname: "item_code", fieldtype: "Data", label: "Item", in_list_view: 1, read_only: 1 },
-
-                                    { fieldname: "qty", fieldtype: "Float", label: "Total Qty", in_list_view: 1, read_only: 1 },
-                                    { fieldname: "billed_qty", fieldtype: "Float", label: "Billed Qty", in_list_view: 1, read_only: 1 },
-                                    { fieldname: "remaining_qty", fieldtype: "Float", label: "Remaining Qty", in_list_view: 1, read_only: 1 },
-
-                                    { fieldname: "remaining_percentage", fieldtype: "Float", label: "Remaining %", in_list_view: 1, read_only: 1 },
-
-                                    { fieldname: "rate", fieldtype: "Currency", label: "Rate", in_list_view: 1, read_only: 1 }
-                                ]
+						fields: item_fields
 					}
 				],
 
-				primary_action_label: "Create Invoice",
+				primary_action_label: __("Create Invoice"),
 
 				primary_action(values) {
 
+					let apply_to_all = values.apply_to_all;
 					let pct = flt(values.percentage);
-
-					if (!(pct > 0 && pct <= 100)) {
-						frappe.msgprint("Enter percentage between 1 and 100.");
-						return;
-					}
-
-					if (pct > remaining) {
-						frappe.msgprint("Only " + remaining + "% remaining overall.");
-						return;
-					}
-
 					let selected = (values.items || []).filter(i => i.include);
 
 					if (!selected.length) {
-						frappe.msgprint("Select at least one item.");
+						frappe.msgprint(__("Select at least one item."));
 						return;
+					}
+
+					if (apply_to_all) {
+						if (!(pct > 0 && pct <= 100)) {
+							frappe.msgprint(__("Enter percentage between 1 and 100."));
+							return;
+						}
+						if (pct > remaining) {
+							frappe.msgprint(__("Only {0}% remaining overall.").format(remaining));
+							return;
+						}
+					} else {
+						let invalid = selected.some(i => !(flt(i.percentage) > 0 && flt(i.percentage) <= 100));
+						if (invalid) {
+							frappe.msgprint(__("Enter a percentage (1–100) for each selected item when not applying to all."));
+							return;
+						}
 					}
 
 					d.hide();
@@ -212,12 +224,19 @@ function open_percentage_dialog(frm) {
 						frm: frm,
 						args: {
 							percentage: pct,
+							apply_to_all: apply_to_all ? 1 : 0,
 							selected_items: selected
 						}
 					});
 				}
 			});
 
+			// Show/hide single percentage based on "Apply to all"
+			d.fields_dict.apply_to_all.$input.on("change", function () {
+				let apply = d.get_value("apply_to_all");
+				d.fields_dict.percentage.df.hidden = !apply;
+				d.fields_dict.percentage.refresh();
+			});
 			d.show();
 		}
 	});


### PR DESCRIPTION
## Feature description
TASK-2026-00231

## Solution description
1. Percentage-based invoicing from Sales Order
1. What it does: Creates Sales Invoices from a Sales Order by a percentage of the order (e.g. 30% now, 70% later) 
    instead of full qty/amount at once.
2. Service items: The percentage applies to amount. Qty can stay 1; the rate is reduced so you bill only that part of the   
    line (e.g. 30% of ₹30,000 = ₹9,000).
3. Stock items: The percentage applies to quantity. You bill that part of the remaining qty at the same rate.
4. No over-billing: The system uses the order’s “per billed” and blocks invoicing more than 100% in total.
5. Amount tracking: Each Sales Order line shows Invoiced amount and Remaining amount. These are updated when a l 
    linked Sales Invoice is submitted or cancelled.
6. Popup options: You can apply one percentage to the whole order (“Apply percentage to all”) or set a different 
    percentage per line in the Create Percentage Invoice dialog. The dialog also shows Total / Invoiced / Remaining 
    amount per item so you can choose what to include.

## Output screenshots (optional)
<img width="1768" height="870" alt="image" src="https://github.com/user-attachments/assets/e49cefa2-3304-42c0-b400-a3f8aef154ec" />
<img width="1768" height="870" alt="image" src="https://github.com/user-attachments/assets/4218e6dc-a6f5-4686-bb11-54a1897a3c65" />


## Was this feature tested on the browsers?
  - Chrome

